### PR TITLE
Set language when opening new editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -348,7 +348,7 @@
         "rest-client.includeAdditionalInfoInResponse": {
           "type": "boolean",
           "default": false,
-          "description": "Include additional information such as request URL and response time"
+          "description": "Include additional information such as request URL and response time when preview is set to use untitled document"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -339,6 +339,16 @@
           "type": "boolean",
           "default": false,
           "description": "Preview response in untitle document if set to true, otherwise displayed in html view"
+        },
+        "rest-client.previewResponseSetUntitledDocumentLanguageByContentType": {
+          "type": "boolean",
+          "default": false,
+          "description": "Attempt to automatically set document language based on Content-Type header when showing each response in new tab"
+        },
+        "rest-client.includeAdditionalInfoInResponse": {
+          "type": "boolean",
+          "default": false,
+          "description": "Include additional information such as request URL and response time"
         }
       }
     }

--- a/src/controllers/requestController.ts
+++ b/src/controllers/requestController.ts
@@ -138,7 +138,9 @@ export class RequestController {
                 if (this._restClientSettings.previewResponseInUntitledDocument) {
                     UntitledFileContentProvider.createHttpResponseUntitledFile(
                         response,
-                        this._restClientSettings.showResponseInDifferentTab
+                        this._restClientSettings.showResponseInDifferentTab,
+                        this._restClientSettings.previewResponseSetUntitledDocumentLanguageByContentType,
+                        this._restClientSettings.includeAdditionalInfoInResponse
                     );
                 } else {
                     await commands.executeCommand('vscode.previewHtml', previewUri, ViewColumn.Two, `Response(${response.elapsedMillionSeconds}ms)`);

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -16,6 +16,9 @@ export interface IRestClientSettings {
     environmentVariables: Map<string, Map<string, string>>;
     mimeAndFileExtensionMapping: Map<string, string>;
     previewResponseInUntitledDocument: boolean;
+    previewResponseSetUntitledDocumentLanguageByContentType: boolean;
+    includeAdditionalInfoInResponse: boolean;
+
 }
 
 export class RestClientSettings implements IRestClientSettings {
@@ -34,6 +37,8 @@ export class RestClientSettings implements IRestClientSettings {
     public environmentVariables: Map<string, Map<string, string>>;
     public mimeAndFileExtensionMapping: Map<string, string>;
     public previewResponseInUntitledDocument: boolean;
+    public previewResponseSetUntitledDocumentLanguageByContentType: boolean;
+    public includeAdditionalInfoInResponse: boolean;
 
     public constructor() {
         workspace.onDidChangeConfiguration(() => {
@@ -62,6 +67,8 @@ export class RestClientSettings implements IRestClientSettings {
         this.mimeAndFileExtensionMapping = restClientSettings.get<Map<string, string>>("mimeAndFileExtensionMapping", new Map<string, string>());
 
         this.previewResponseInUntitledDocument = restClientSettings.get<boolean>("previewResponseInUntitledDocument", false);
+        this.previewResponseSetUntitledDocumentLanguageByContentType = restClientSettings.get<boolean>("previewResponseSetUntitledDocumentLanguageByContentType", false);
+        this.includeAdditionalInfoInResponse = restClientSettings.get<boolean>("includeAdditionalInfoInResponse", false);
 
         let httpSettings = workspace.getConfiguration('http');
         this.proxy = httpSettings.get<string>('proxy', undefined);

--- a/src/views/responseUntitledFileContentProvider.ts
+++ b/src/views/responseUntitledFileContentProvider.ts
@@ -8,6 +8,9 @@ import { EOL } from 'os';
 export class UntitledFileContentProvider {
     private static createdFiles: TextDocument[] = [];
     public static createHttpResponseUntitledFile(response: HttpResponse, createNewFile: boolean) {
+        // Currently unable to find a way to change language through API for already opened file.
+        // So when reusing same editor, default to 'http'
+        const language = createNewFile ? UntitledFileContentProvider.languageFromContentType(response) : 'http';
         if (!createNewFile && UntitledFileContentProvider.createdFiles.length > 0) {
             let updateDocument = UntitledFileContentProvider.createdFiles.slice(-1)[0];
 
@@ -17,25 +20,42 @@ export class UntitledFileContentProvider {
                     textEditor.edit(edit => {
                         // get previous response file Range
                         var startPosition = new Position(0, 0);
-                        var endPoistion =  updateDocument.lineAt(updateDocument.lineCount - 1).range.end;
-                        edit.replace(new Range(startPosition, endPoistion), UntitledFileContentProvider.formatResponse(response));
+                        var endPosition =  updateDocument.lineAt(updateDocument.lineCount - 1).range.end;
+                        edit.replace(new Range(startPosition, endPosition), UntitledFileContentProvider.formatResponse(response, language));
                     });
                 });
                 return;
             }
         }
-        workspace.openTextDocument({ 'language': 'http' }).then(document => {
+
+        workspace.openTextDocument({ 'language': language }).then(document => {
             UntitledFileContentProvider.createdFiles.push(document);
             window.showTextDocument(document, ViewColumn.Two, false).then(textEditor => {
                 textEditor.edit(edit => {
-                    edit.insert(new Position(0, 0), UntitledFileContentProvider.formatResponse(response));
+                    edit.insert(new Position(0, 0), UntitledFileContentProvider.formatResponse(response, language));
                 });
             });
         });
     }
 
-    private static formatResponse(response: HttpResponse): string {
+    private static languageFromContentType(response: HttpResponse): string {
+        let contentType = response.getResponseHeaderValue("Content-Type");
+        if (!contentType) return 'http';
+
+        let types = ['xml', 'json', 'html', 'css'];
+        for (let type of types) {
+            if (contentType.includes(type)) return type;
+        };
+
+        return 'http';
+    }
+
+    private static formatResponse(response: HttpResponse, language: string): string {
+        let commentBegin = UntitledFileContentProvider.commentBegin(language);
+        let commentEnd   = UntitledFileContentProvider.commentEnd(language);
         let responseStatusLine = `HTTP/${response.httpVersion} ${response.statusCode} ${response.statusMessage}${EOL}`;
+        let requestURL = `Request: ${response.requestUrl}${EOL}`;
+        let elapsedTime = `Elapsed time: ${response.elapsedMillionSeconds}ms${EOL}`;
         let headers = '';
         for (var header in response.headers) {
             if (response.headers.hasOwnProperty(header)) {
@@ -47,6 +67,27 @@ export class UntitledFileContentProvider {
             }
         }
         let body = ResponseFormatUtility.FormatBody(response.body, response.getResponseHeaderValue("content-type"));
-        return `${responseStatusLine}${headers}${EOL}${body}`;
+        return `${commentBegin}${EOL}${requestURL}${elapsedTime}${responseStatusLine}${headers}${commentEnd}${EOL}${body}`;
+    }
+
+    private static commentBegin(language: string) {
+        const REST_RESPONSE = 'REST Response Information:';
+        let commentStyle = {
+            xml: '<!-- ',
+            json: '/* ',
+            html: '<!-- ',
+            css: '/* '
+        }
+        return commentStyle[language] ? commentStyle[language] + REST_RESPONSE: '';
+    }
+
+    private static commentEnd(language: string) {
+        let commentStyle = {
+            xml: '-->',
+            json: '*/',
+            html: '-->',
+            css: '*/'
+        }
+        return commentStyle[language] ? commentStyle[language] : '';
     }
 }

--- a/src/views/responseUntitledFileContentProvider.ts
+++ b/src/views/responseUntitledFileContentProvider.ts
@@ -7,10 +7,13 @@ import { EOL } from 'os';
 
 export class UntitledFileContentProvider {
     private static createdFiles: TextDocument[] = [];
-    public static createHttpResponseUntitledFile(response: HttpResponse, createNewFile: boolean) {
+    public static createHttpResponseUntitledFile(response: HttpResponse, createNewFile: boolean, autoSetLanguage: boolean, additionalInfo: boolean) {
         // Currently unable to find a way to change language through API for already opened file.
         // So when reusing same editor, default to 'http'
-        const language = createNewFile ? UntitledFileContentProvider.languageFromContentType(response) : 'http';
+        // This can be fixed when vscode issue #1800 is resolved
+        if (!createNewFile) autoSetLanguage = false; // override for now until vscode issue is resolved
+
+        const language = (createNewFile && autoSetLanguage) ? UntitledFileContentProvider.languageFromContentType(response) : 'http';
         if (!createNewFile && UntitledFileContentProvider.createdFiles.length > 0) {
             let updateDocument = UntitledFileContentProvider.createdFiles.slice(-1)[0];
 
@@ -21,7 +24,7 @@ export class UntitledFileContentProvider {
                         // get previous response file Range
                         var startPosition = new Position(0, 0);
                         var endPosition =  updateDocument.lineAt(updateDocument.lineCount - 1).range.end;
-                        edit.replace(new Range(startPosition, endPosition), UntitledFileContentProvider.formatResponse(response, language));
+                        edit.replace(new Range(startPosition, endPosition), UntitledFileContentProvider.formatResponse(response, language, additionalInfo, autoSetLanguage));
                     });
                 });
                 return;
@@ -32,7 +35,7 @@ export class UntitledFileContentProvider {
             UntitledFileContentProvider.createdFiles.push(document);
             window.showTextDocument(document, ViewColumn.Two, false).then(textEditor => {
                 textEditor.edit(edit => {
-                    edit.insert(new Position(0, 0), UntitledFileContentProvider.formatResponse(response, language));
+                    edit.insert(new Position(0, 0), UntitledFileContentProvider.formatResponse(response, language, additionalInfo, autoSetLanguage));
                 });
             });
         });
@@ -50,12 +53,37 @@ export class UntitledFileContentProvider {
         return 'http';
     }
 
-    private static formatResponse(response: HttpResponse, language: string): string {
+    private static formatResponse(response: HttpResponse, language: string, additionalInfo: boolean, autoSetLanguage: boolean) {
+        const {responseStatusLine, headers, body} = UntitledFileContentProvider.extractStandardResponseInformation(response);
+        let responseInformation;
+        if(additionalInfo) {
+            const formattedAdditionalInfo = UntitledFileContentProvider.formatAdditionalResponseInformation(response);
+            responseInformation = `${responseStatusLine}${formattedAdditionalInfo}${headers}`;
+        } else {
+            responseInformation = `${responseStatusLine}${headers}`;
+        } 
+
+        return autoSetLanguage ? UntitledFileContentProvider.formatResponseForLanguage(responseInformation, body, language) : 
+                                 UntitledFileContentProvider.formatResponseDefault(responseInformation, body);
+    }
+
+    private static formatResponseDefault(responseInformation:string, responseBody: string) {
+        return `${responseInformation}${EOL}${responseBody}`;
+    }
+
+    private static formatResponseForLanguage(responseInformation:string, responseBody: string, language: string) {
         let commentBegin = UntitledFileContentProvider.commentBegin(language);
         let commentEnd   = UntitledFileContentProvider.commentEnd(language);
+        return `${commentBegin}${EOL}${responseInformation}${commentEnd}${EOL}${responseBody}`;
+    }
+    private static formatAdditionalResponseInformation(response: HttpResponse) {
+        let requestURL   = `Request: ${response.requestUrl}${EOL}`;
+        let elapsedTime  = `Elapsed time: ${response.elapsedMillionSeconds}ms${EOL}`;
+        return `${requestURL}${elapsedTime}`;
+    }
+
+    private static extractStandardResponseInformation(response: HttpResponse) {
         let responseStatusLine = `HTTP/${response.httpVersion} ${response.statusCode} ${response.statusMessage}${EOL}`;
-        let requestURL = `Request: ${response.requestUrl}${EOL}`;
-        let elapsedTime = `Elapsed time: ${response.elapsedMillionSeconds}ms${EOL}`;
         let headers = '';
         for (var header in response.headers) {
             if (response.headers.hasOwnProperty(header)) {
@@ -67,7 +95,7 @@ export class UntitledFileContentProvider {
             }
         }
         let body = ResponseFormatUtility.FormatBody(response.body, response.getResponseHeaderValue("content-type"));
-        return `${commentBegin}${EOL}${requestURL}${elapsedTime}${responseStatusLine}${headers}${commentEnd}${EOL}${body}`;
+        return {responseStatusLine, headers, body};
     }
 
     private static commentBegin(language: string) {

--- a/src/views/responseUntitledFileContentProvider.ts
+++ b/src/views/responseUntitledFileContentProvider.ts
@@ -106,7 +106,7 @@ export class UntitledFileContentProvider {
             html: '<!-- ',
             css: '/* '
         }
-        return commentStyle[language] ? commentStyle[language] + REST_RESPONSE: '';
+        return commentStyle[language] ? commentStyle[language] + REST_RESPONSE : '';
     }
 
     private static commentEnd(language: string) {


### PR DESCRIPTION
The new feature is working great.  Thanks!
After using this for a bit, I found a couple of things that improve my work.

1.  I set the language automatically when opening a new editor.  I wanted to do this also for reusing the same editor, but I couldn't find an API to do it.
2.  Included request url and elapsed time in the response document
3.  Made the response information into comments which makes it play nice with the language theme and coloring.

Hopefully you can consider these changes.  Thanks!