### PR TITLE
Switch to new API for opening editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/Huachao/vscode-restclient.git"
   },
   "engines": {
-    "vscode": "^1.9.0"
+    "vscode": "^1.11.0"
   },
   "categories": [
     "Other",

--- a/src/views/responseUntitledFileContentProvider.ts
+++ b/src/views/responseUntitledFileContentProvider.ts
@@ -31,13 +31,10 @@ export class UntitledFileContentProvider {
             }
         }
 
-        workspace.openTextDocument({ 'language': language }).then(document => {
+        const content = UntitledFileContentProvider.formatResponse(response, language, additionalInfo, autoSetLanguage);
+        workspace.openTextDocument({ 'language': language, 'content': content }).then(document => {
             UntitledFileContentProvider.createdFiles.push(document);
-            window.showTextDocument(document, ViewColumn.Two, false).then(textEditor => {
-                textEditor.edit(edit => {
-                    edit.insert(new Position(0, 0), UntitledFileContentProvider.formatResponse(response, language, additionalInfo, autoSetLanguage));
-                });
-            });
+            window.showTextDocument(document, ViewColumn.Two, false);
         });
     }
 


### PR DESCRIPTION
This is a change to the open response in Untitled document.
VSCode 1.11 has a new parameter on the API which allows to set the content on opening.

I think this is better for these reasons:
1)  This allows the document to open without a previous undo.  So if you hit undo, you will no longer get a blank document
2)  Since the document is opened in a state of not dirty, you can close the document without the editor giving you a popup asking if you want to close the document.

@Huachao Let me know what you think