### PR TITLE
use new vscode api to preview untitled document

### DIFF
--- a/package.json
+++ b/package.json
@@ -411,7 +411,7 @@
     "mocha": "^3.2.0",
     "tslint": "^4.2.0",
     "typescript": "^2.0.3",
-    "vscode": "^1.1.0"
+    "vscode": "^1.0.0"
   },
   "dependencies": {
     "applicationinsights": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "url": "https://github.com/Huachao/vscode-restclient.git"
   },
   "engines": {
-    "vscode": "^1.11.0"
+    "vscode": "^1.12.0"
   },
   "categories": [
     "Other",
@@ -411,7 +411,7 @@
     "mocha": "^3.2.0",
     "tslint": "^4.2.0",
     "typescript": "^2.0.3",
-    "vscode": "^1.0.0"
+    "vscode": "^1.1.0"
   },
   "dependencies": {
     "applicationinsights": "^0.18.0",


### PR DESCRIPTION
vscode 1.12 added a new `showTextDocument` API.

Using this API, it is now possible to reuse the same untitled tab and set the language.