### PR TITLE
Allow hiding status bar item via settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -442,7 +442,7 @@
           "scope": "resource",
           "description": "Response preview output option. 'full' for whole response message(status line, headers and body). 'headers' for response headers(as well as status line). 'body' for response body only. 'exchange' for whole HTTP exchange (request and response)"
         },
-        "rest-client.showStatusBarItem": {
+        "rest-client.showEnvironmentStatusBarItem": {
           "type": "boolean",
           "default": true,
           "scope": "resource",

--- a/package.json
+++ b/package.json
@@ -441,6 +441,12 @@
           "default": "full",
           "scope": "resource",
           "description": "Response preview output option. 'full' for whole response message(status line, headers and body). 'headers' for response headers(as well as status line). 'body' for response body only. 'exchange' for whole HTTP exchange (request and response)"
+        },
+        "rest-client.showStatusBarItem": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource",
+          "description": "Show environment picker in status bar"
         }
       }
     }

--- a/src/controllers/environmentController.ts
+++ b/src/controllers/environmentController.ts
@@ -19,7 +19,7 @@ export class EnvironmentController {
     public constructor(initEnvironment: EnvironmentPickItem) {
         this._restClientSettings = new RestClientSettings();
 
-        if (this._restClientSettings.showStatusBarItem) {
+        if (this._restClientSettings.showEnvironmentStatusBarItem) {
             this._environmentStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
             this._environmentStatusBarItem.command = 'rest-client.switch-environment';
             this._environmentStatusBarItem.text = initEnvironment.label;
@@ -49,7 +49,7 @@ export class EnvironmentController {
             return;
         }
 
-        if (this._restClientSettings.showStatusBarItem) {
+        if (this._restClientSettings.showEnvironmentStatusBarItem) {
             this._environmentStatusBarItem.text = item.label;
         }
 

--- a/src/controllers/environmentController.ts
+++ b/src/controllers/environmentController.ts
@@ -17,12 +17,15 @@ export class EnvironmentController {
     private _restClientSettings: RestClientSettings;
 
     public constructor(initEnvironment: EnvironmentPickItem) {
-        this._environmentStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
-        this._environmentStatusBarItem.command = 'rest-client.switch-environment';
-        this._environmentStatusBarItem.text = initEnvironment.label;
-        this._environmentStatusBarItem.tooltip = 'Switch REST Client Environment';
-        this._environmentStatusBarItem.show();
         this._restClientSettings = new RestClientSettings();
+
+        if (this._restClientSettings.showStatusBarItem) {
+            this._environmentStatusBarItem = window.createStatusBarItem(StatusBarAlignment.Right, 100);
+            this._environmentStatusBarItem.command = 'rest-client.switch-environment';
+            this._environmentStatusBarItem.text = initEnvironment.label;
+            this._environmentStatusBarItem.tooltip = 'Switch REST Client Environment';
+            this._environmentStatusBarItem.show();
+        }
     }
 
     @trace('Switch Environment')
@@ -46,7 +49,9 @@ export class EnvironmentController {
             return;
         }
 
-        this._environmentStatusBarItem.text = item.label;
+        if (this._restClientSettings.showStatusBarItem) {
+            this._environmentStatusBarItem.text = item.label;
+        }
 
         await PersistUtility.saveEnvironment(item);
     }

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -35,7 +35,7 @@ export class RestClientSettings implements IRestClientSettings {
     public proxyStrictSSL: boolean;
     public rememberCookiesForSubsequentRequests: boolean;
     public enableTelemetry: boolean;
-    public showStatusBarItem: boolean;
+    public showEnvironmentStatusBarItem: boolean;
     public excludeHostsForProxy: string[];
     public fontSize?: number;
     public fontFamily: string;
@@ -88,7 +88,7 @@ export class RestClientSettings implements IRestClientSettings {
         this.proxy = httpSettings.get<string>('proxy', undefined);
         this.proxyStrictSSL = httpSettings.get<boolean>('proxyStrictSSL', false);
         this.enableTelemetry = httpSettings.get<boolean>('enableTelemetry', true);
-        this.showStatusBarItem = restClientSettings.get<boolean>('showStatusBarItem', true);
+        this.showEnvironmentStatusBarItem = restClientSettings.get<boolean>('showEnvironmentStatusBarItem', true);
     }
 
     private getWorkspaceConfiguration(): WorkspaceConfiguration {

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -35,6 +35,7 @@ export class RestClientSettings implements IRestClientSettings {
     public proxyStrictSSL: boolean;
     public rememberCookiesForSubsequentRequests: boolean;
     public enableTelemetry: boolean;
+    public showStatusBarItem: boolean;
     public excludeHostsForProxy: string[];
     public fontSize?: number;
     public fontFamily: string;
@@ -87,6 +88,7 @@ export class RestClientSettings implements IRestClientSettings {
         this.proxy = httpSettings.get<string>('proxy', undefined);
         this.proxyStrictSSL = httpSettings.get<boolean>('proxyStrictSSL', false);
         this.enableTelemetry = httpSettings.get<boolean>('enableTelemetry', true);
+        this.showStatusBarItem = restClientSettings.get<boolean>('showStatusBarItem', true);
     }
 
     private getWorkspaceConfiguration(): WorkspaceConfiguration {


### PR DESCRIPTION
This is such a minor nitpick but it feels a bit distracting for me when i'm editing files that completely unrelated to REST client but that status bar switcher is always present 😄 

This pull request adds `showStatusBarItem` boolean parameter configurable from settings.
Since we can switch environments via command palette anyway we aren't losing in functionality with this new config param set to `false`.