### PR TITLE
Add built-in support for Azure AD auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Content-Type: application/json
 Global variables provide a pre-defined set of variables that can be used in any part of the request(Url/Headers/Body) in the format `{{$variableName}}`. Currently, we provide a few dynamic variables which you can use in your requests. The variable names are _case-sensitive_.
 * `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>]}}`: Add an Azure Active Directory token based on the following options (must be specified in order):
 
-  `new`: Optional. Specify `new` to force re-authentication and get a new token for the specified directory. Default: Reuse non-expired token for the specified directory from an in-memory cache. (Restart Code to clear the cache.)
+  `new`: Optional. Specify `new` to force re-authentication and get a new token for the specified directory. Default: Reuse non-expired token for the specified directory from an in-memory cache. (Use `F1 > Rest Client: Clear Azure AD token cache` or restart Code to clear the cache.)
 
   `public|cn|de|us|ppe`: Optional. Specify top-level domain (TLD) to get a token for the specified government cloud, `public` for the public cloud, or `ppe` for internal testing. Default: TLD of the REST endpoint; `public` if not valid.
 
@@ -442,7 +442,7 @@ GET https://management.azure.com/subscriptions
 Authorization: {{$aadToken new contoso.com}}
 ```
 
-_**NOTE:** REST Client uses an in-memory token cache that clears when Code is restarted._
+_**NOTE:** REST Client uses an in-memory token cache that clears when Code is restarted. You can clear the token cache manually by using `F1 > Rest Client: Clear Azure AD token cache`._
 
 _**NOTE:** `new` can be used with any other options, as long as it's specified first. Order is important for all options._
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support both __environment__ and __file__ custom variables
     - Auto completion and hover support for both environment and file custom variables
     - Go to definition and find all references support _ONLY_ for file custom variables
-    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [tenantId]}}`
+    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [domain|tenantId]}}`
     - Easily create/update/delete environments and custom variables in setting file
     - Support environment switch
     - Support shared environment to provide variables that available in all environments
@@ -368,8 +368,8 @@ Content-Type: application/json
 Global variables provide a pre-defined set of variables that can be used in any part of the request(Url/Headers/Body) in the format `{{$variableName}}`. Currently, we provide a few dynamic variables which you can use in your requests. The variable names are _case-sensitive_.
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$randomInt min max}}`: Returns a random integer between min (included) and max (excluded)
-* `{{$aadToken [tenantId]}}`: Add `Authorization: {{$aadToken}}` to attach an Azure Active Directory token to the request
-  *tenantId*: Optional. Unique identifier (GUID) for the directory. Default is account's home directory.
+* `{{$aadToken [directory]}}`: Add `Authorization: {{$aadToken}}` to attach an Azure Active Directory token to the request
+  `directory`: Optional. Domain or GUID for the directory to sign in to. Default is account's home directory.
 * `{{$timestamp}}`: Add UTC timestamp of now. You can even specify any date time based on current time in the format `{{$timestamp number option}}`, e.g., to represent 3 hours ago, simply `{{$timestamp -3 h}}`; to represent the day after tomorrow, simply `{{$timestamp 2 d}}`. The option string you can specify in timestamp are:
 
 Option | Description

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support both __environment__ and __file__ custom variables
     - Auto completion and hover support for both environment and file custom variables
     - Go to definition and find all references support _ONLY_ for file custom variables
-    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken}}`
+    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [tenantId]}}`
     - Easily create/update/delete environments and custom variables in setting file
     - Support environment switch
     - Support shared environment to provide variables that available in all environments
@@ -368,7 +368,8 @@ Content-Type: application/json
 Global variables provide a pre-defined set of variables that can be used in any part of the request(Url/Headers/Body) in the format `{{$variableName}}`. Currently, we provide a few dynamic variables which you can use in your requests. The variable names are _case-sensitive_.
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$randomInt min max}}`: Returns a random integer between min (included) and max (excluded)
-* `{{$aadToken}}`: Specify within the `Authorization` header to embed an Azure Active Directory token (i.e. `Authorization: {{$aadToken}}`)
+* `{{$aadToken [tenantId]}}`: Add `Authorization: {{$aadToken}}` to attach an Azure Active Directory token to the request
+  *tenantId*: Optional. Unique identifier (GUID) for the directory. Default is account's home directory.
 * `{{$timestamp}}`: Add UTC timestamp of now. You can even specify any date time based on current time in the format `{{$timestamp number option}}`, e.g., to represent 3 hours ago, simply `{{$timestamp -3 h}}`; to represent the day after tomorrow, simply `{{$timestamp 2 d}}`. The option string you can specify in timestamp are:
 
 Option | Description

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support both __environment__ and __file__ custom variables
     - Auto completion and hover support for both environment and file custom variables
     - Go to definition and find all references support _ONLY_ for file custom variables
-    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [new] [domain|tenantId]}}`
+    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>]}}`
     - Easily create/update/delete environments and custom variables in setting file
     - Support environment switch
     - Support shared environment to provide variables that available in all environments
@@ -217,7 +217,7 @@ Another icon in the upper right corner of the response preview tab is the `Save 
 ```
 
 ## Authentication
-We have supported some most common authentication schemes like _Basic Auth_, _Digest Auth_ and _SSL Client Certificates_. 
+We have supported some most common authentication schemes like _Basic Auth_, _Digest Auth_ and _SSL Client Certificates_.
 
 See Global Variables for information about built-in support for Azure Active Directory.
 
@@ -368,13 +368,13 @@ Content-Type: application/json
 
 ### Global Variables
 Global variables provide a pre-defined set of variables that can be used in any part of the request(Url/Headers/Body) in the format `{{$variableName}}`. Currently, we provide a few dynamic variables which you can use in your requests. The variable names are _case-sensitive_.
-* `{{$aadToken [new] [domain|tenantId]}}`: Add an Azure Active Directory token
+* `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>]}}`: Add an Azure Active Directory token based on the following options (must be specified in order):
 
   `new`: Optional. Specify `new` to get a new token. Default: Reuse non-expired token for the specified directory.
 
-  `domain|tenantId`: Optional. Domain or GUID for the directory to sign in to. Default: Account home directory.
+  `public|cn|de|us|ppe`: Optional. Specify top-level domain (TLD) to get a token for the specified government cloud, `public` for the public cloud, or `ppe` for internal testing. Default: TLD of the REST endpoint; `public` if not valid.
 
-  _**NOTE:** Government clouds (e.g. US, China, Germany) are automatically handled by the top-level domain of the endpoint (e.g. `*.de` will result in an Azure Germany token)._
+  `<domain|tenantId>`: Optional. Domain or GUID for the directory to sign in to. Default: Account home directory.
 
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$randomInt min max}}`: Returns a random integer between min (included) and max (excluded)
@@ -441,7 +441,26 @@ GET https://management.azure.com/subscriptions
     ?api-version=2017-08-01
 Authorization: {{$aadToken new contoso.com}}
 ```
-_**NOTE:** "new" can be used with or without an explicit directory._
+
+_**NOTE:** "new" can be used with any other options, as long as it's first._
+
+Implicit cloud selection (via REST endpoint TLD):
+
+```http
+GET https://management.microsoftazure.de/subscriptions
+    ?api-version=2017-08-01
+Authorization: {{$aadToken}}
+```
+
+Explicit cloud selection:
+
+```http
+GET https://management.usgovcloudapi.net/subscriptions
+    ?api-version=2017-08-01
+Authorization: {{$aadToken us}}
+```
+
+_**NOTE:** Azure China does not work like the other clouds. Use of Azure China is allowed, but may fail._
 
 _**NOTE:** Use of Azure AD is not limited to Azure APIs. Inclusion here is for demonstration purposes only._
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support both __environment__ and __file__ custom variables
     - Auto completion and hover support for both environment and file custom variables
     - Go to definition and find all references support _ONLY_ for file custom variables
-    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}` and `{{$timestamp}}`
+    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken}}`
     - Easily create/update/delete environments and custom variables in setting file
     - Support environment switch
     - Support shared environment to provide variables that available in all environments
@@ -368,6 +368,7 @@ Content-Type: application/json
 Global variables provide a pre-defined set of variables that can be used in any part of the request(Url/Headers/Body) in the format `{{$variableName}}`. Currently, we provide a few dynamic variables which you can use in your requests. The variable names are _case-sensitive_.
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$randomInt min max}}`: Returns a random integer between min (included) and max (excluded)
+* `{{$aadToken}}`: Specify within the `Authorization` header to embed an Azure Active Directory token (i.e. `Authorization: {{$aadToken}}`)
 * `{{$timestamp}}`: Add UTC timestamp of now. You can even specify any date time based on current time in the format `{{$timestamp number option}}`, e.g., to represent 3 hours ago, simply `{{$timestamp -3 h}}`; to represent the day after tomorrow, simply `{{$timestamp 2 d}}`. The option string you can specify in timestamp are:
 
 Option | Description

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support both __environment__ and __file__ custom variables
     - Auto completion and hover support for both environment and file custom variables
     - Go to definition and find all references support _ONLY_ for file custom variables
-    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>]}}`
+    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [new|clear] [public|cn|de|us|ppe] [<domain|tenantId>]}}`
     - Easily create/update/delete environments and custom variables in setting file
     - Support environment switch
     - Support shared environment to provide variables that available in all environments
@@ -368,9 +368,9 @@ Content-Type: application/json
 
 ### Global Variables
 Global variables provide a pre-defined set of variables that can be used in any part of the request(Url/Headers/Body) in the format `{{$variableName}}`. Currently, we provide a few dynamic variables which you can use in your requests. The variable names are _case-sensitive_.
-* `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>]}}`: Add an Azure Active Directory token based on the following options (must be specified in order):
+* `{{$aadToken [new|clear] [public|cn|de|us|ppe] [<domain|tenantId>]}}`: Add an Azure Active Directory token based on the following options (must be specified in order):
 
-  `new`: Optional. Specify `new` to get a new token. Default: Reuse non-expired token for the specified directory.
+  `new|clear`: Optional. Specify `new` to get a new token and `clear` (or just restart Code) to fully clear the in-memory token cache. Default: Reuse non-expired token for the specified directory.
 
   `public|cn|de|us|ppe`: Optional. Specify top-level domain (TLD) to get a token for the specified government cloud, `public` for the public cloud, or `ppe` for internal testing. Default: TLD of the REST endpoint; `public` if not valid.
 
@@ -434,7 +434,7 @@ GET https://management.azure.com/subscriptions
 Authorization: {{$aadToken contoso.com}}
 ```
 
-Do not reuse older token -- force re-authentication (e.g. switch account):
+Do not reuse older token -- force re-authentication for current directory (e.g. switch account):
 
 ```http
 GET https://management.azure.com/subscriptions
@@ -442,7 +442,17 @@ GET https://management.azure.com/subscriptions
 Authorization: {{$aadToken new contoso.com}}
 ```
 
-_**NOTE:** "new" can be used with any other options, as long as it's first._
+Clear in-memory tocken cache -- force re-authentication for all directories:
+
+```http
+GET https://management.azure.com/subscriptions
+    ?api-version=2017-08-01
+Authorization: {{$aadToken clear contoso.com}}
+```
+
+_**NOTE:** REST Client uses an in-memory token cache that clears when Code is restarted.
+
+_**NOTE:** `new` and `clear` can be used with any other options, as long as they're first. Order is important for all options._
 
 Implicit cloud selection (via REST endpoint TLD):
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support both __environment__ and __file__ custom variables
     - Auto completion and hover support for both environment and file custom variables
     - Go to definition and find all references support _ONLY_ for file custom variables
-    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [new|clear] [public|cn|de|us|ppe] [<domain|tenantId>]}}`
+    - Provide system dynamic variables `{{$guid}}`, `{{$randomInt min max}}`, `{{$timestamp}}`, and `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>]}}`
     - Easily create/update/delete environments and custom variables in setting file
     - Support environment switch
     - Support shared environment to provide variables that available in all environments
@@ -368,13 +368,13 @@ Content-Type: application/json
 
 ### Global Variables
 Global variables provide a pre-defined set of variables that can be used in any part of the request(Url/Headers/Body) in the format `{{$variableName}}`. Currently, we provide a few dynamic variables which you can use in your requests. The variable names are _case-sensitive_.
-* `{{$aadToken [new|clear] [public|cn|de|us|ppe] [<domain|tenantId>]}}`: Add an Azure Active Directory token based on the following options (must be specified in order):
+* `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>]}}`: Add an Azure Active Directory token based on the following options (must be specified in order):
 
-  `new|clear`: Optional. Specify `new` to get a new token and `clear` (or just restart Code) to fully clear the in-memory token cache. Default: Reuse non-expired token for the specified directory.
+  `new`: Optional. Specify `new` to force re-authentication and get a new token for the specified directory. Default: Reuse non-expired token for the specified directory from an in-memory cache. (Restart Code to clear the cache.)
 
   `public|cn|de|us|ppe`: Optional. Specify top-level domain (TLD) to get a token for the specified government cloud, `public` for the public cloud, or `ppe` for internal testing. Default: TLD of the REST endpoint; `public` if not valid.
 
-  `<domain|tenantId>`: Optional. Domain or GUID for the directory to sign in to. Default: Account home directory.
+  `<domain|tenantId>`: Optional. Domain or tenant id for the directory to sign in to. Default: Account home directory.
 
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$randomInt min max}}`: Returns a random integer between min (included) and max (excluded)
@@ -442,17 +442,9 @@ GET https://management.azure.com/subscriptions
 Authorization: {{$aadToken new contoso.com}}
 ```
 
-Clear in-memory tocken cache -- force re-authentication for all directories:
+_**NOTE:** REST Client uses an in-memory token cache that clears when Code is restarted._
 
-```http
-GET https://management.azure.com/subscriptions
-    ?api-version=2017-08-01
-Authorization: {{$aadToken clear contoso.com}}
-```
-
-_**NOTE:** REST Client uses an in-memory token cache that clears when Code is restarted.
-
-_**NOTE:** `new` and `clear` can be used with any other options, as long as they're first. Order is important for all options._
+_**NOTE:** `new` can be used with any other options, as long as it's specified first. Order is important for all options._
 
 Implicit cloud selection (via REST endpoint TLD):
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "onCommand:rest-client.save-response",
     "onCommand:rest-client.save-response-body",
     "onCommand:rest-client.switch-environment",
+    "onCommand:rest-client.clear-aad-token-cache",
     "onLanguage:http"
   ],
   "main": "./out/src/extension",
@@ -146,6 +147,11 @@
       {
         "command": "rest-client.copy-request-as-curl",
         "title": "Copy Request As cURL",
+        "category": "Rest Client"
+      },
+      {
+        "command": "rest-client.clear-aad-token-cache",
+        "title": "Clear Azure AD token cache",
         "category": "Rest Client"
       }
     ],

--- a/package.json
+++ b/package.json
@@ -486,6 +486,7 @@
     "vscode": "^1.0.0"
   },
   "dependencies": {
+    "adal-node": "^0.1.26",
     "applicationinsights": "^0.18.0",
     "autolinker": "^1.4.0",
     "code-highlight-linenums": "^0.2.1",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -25,6 +25,7 @@ export const RandomIntDescription = "Returns a random integer between min (inclu
 export const AzureActiveDirectoryVariableName = "$aadToken";
 export const AzureActiveDirectoryDescription = "Prompts to sign in to Azure AD and adds the token to the request";
 export const AzureActiveDirectoryClientId = "aebc6443-996d-45c2-90f0-388ff96faa56";  // VS Code client id
+export const AzureActiveDirectoryForceNewOption = "new";
 export const AzureActiveDirectorySignInUrls = {
     ppe: "https://login.windows-ppe.net/",  // for testing purposes only
     public: "https://login.microsoftonline.com/",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,9 +24,14 @@ export const RandomIntDescription = "Returns a random integer between min (inclu
 
 export const AzureActiveDirectoryVariableName = "$aadToken";
 export const AzureActiveDirectoryDescription = "Prompts to sign in to Azure AD and adds the token to the request";
-export const AzureActiveDirectoryClientId = "aebc6443-996d-45c2-90f0-388ff96faa56";  // VS Code client id
+/**
+ * NOTE: The client id represents an AAD app people sign in to. The client id is sent to AAD to indicate what app
+ * is requesting a token for the user. When the user signs in, AAD shows the name of the app to confirm the user is
+ * authorizing the right app to act on their behalf. We're using Visual Studio Code's client id since that is the
+ * overarching app people will think of when they are signing in.
+ */
+export const AzureActiveDirectoryClientId = "aebc6443-996d-45c2-90f0-388ff96faa56";
 export const AzureActiveDirectoryForceNewOption = "new";
-export const AzureActiveDirectoryClearCacheOption = "clear";
 export const AzureClouds = {
     ppe: {
         aad: "https://login.windows-ppe.net/",  // for testing purposes only

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,12 +26,28 @@ export const AzureActiveDirectoryVariableName = "$aadToken";
 export const AzureActiveDirectoryDescription = "Prompts to sign in to Azure AD and adds the token to the request";
 export const AzureActiveDirectoryClientId = "aebc6443-996d-45c2-90f0-388ff96faa56";  // VS Code client id
 export const AzureActiveDirectoryForceNewOption = "new";
-export const AzureActiveDirectorySignInUrls = {
-    ppe: "https://login.windows-ppe.net/",  // for testing purposes only
-    public: "https://login.microsoftonline.com/",
-    cn: "https://login.chinacloudapi.cn/",
-    de: "https://login.microsoftonline.de/",
-    us: "https://login.microsoftonline.us/",
+export const AzureClouds = {
+    ppe: {
+        aad: "https://login.windows-ppe.net/",  // for testing purposes only
+        arm: "https://api-dogfood.resources.windows-int.net/",
+        armAudience: "https://management.azure.com/",
+    },
+    public: {
+        aad: "https://login.microsoftonline.com/",
+        arm: "https://management.azure.com/",
+    },
+    cn: {
+        aad: "https://login.chinacloudapi.cn/",
+        arm: "https://management.chinacloudapi.cn/",
+    },
+    de: {
+        aad: "https://login.microsoftonline.de/",
+        arm: "https://management.microsoftazure.de/",
+    },
+    us: {
+        aad: "https://login.microsoftonline.us/",
+        arm: "https://management.usgovcloudapi.net/",
+    },
 };
 
 export const CommentIdentifiersRegex: RegExp = /^\s*(#|\/{2})/;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,12 @@ export const TimeStampVariableName = "$timestamp";
 export const TimeStampVariableDescription = "Add a number of milliseconds between 1970/1/1 UTC Time and now. \
  You can also provide the offset with current time in the format {{$timestamp number string}}";
 export const GuidVariableName = "$guid";
+export const GuidVariableDescription = "Add a RFC 4122 v4 UUID";
+export const RandomInt = "$randomInt";
+export const RandomIntDescription = "Returns a random integer between min (included) and max (excluded)";
+
 export const AzureActiveDirectoryVariableName = "$aadToken";
+export const AzureActiveDirectoryDescription = "Prompts to sign in to Azure AD and adds the token to the request";
 export const AzureActiveDirectoryClientId = "aebc6443-996d-45c2-90f0-388ff96faa56";  // VS Code client id
 export const AzureActiveDirectorySignInUrls = {
     ppe: "https://login.windows-ppe.net/",  // for testing purposes only
@@ -27,9 +32,6 @@ export const AzureActiveDirectorySignInUrls = {
     de: "https://login.microsoftonline.de/",
     us: "https://login.microsoftonline.us/",
 };
-export const GuidVariableDescription = "Add a RFC 4122 v4 UUID";
-export const RandomInt = "$randomInt";
-export const RandomIntDescription = "Returns a random integer between min (included) and max (excluded)";
 
 export const CommentIdentifiersRegex: RegExp = /^\s*(#|\/{2})/;
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,6 +18,15 @@ export const TimeStampVariableName = "$timestamp";
 export const TimeStampVariableDescription = "Add a number of milliseconds between 1970/1/1 UTC Time and now. \
  You can also provide the offset with current time in the format {{$timestamp number string}}";
 export const GuidVariableName = "$guid";
+export const AzureActiveDirectoryVariableName = "$aadToken";
+export const AzureActiveDirectoryClientId = "aebc6443-996d-45c2-90f0-388ff96faa56";  // VS Code client id
+export const AzureActiveDirectorySignInUrls = {
+    ppe: "https://login.windows-ppe.net/",  // for testing purposes only
+    public: "https://login.microsoftonline.com/",
+    cn: "https://login.chinacloudapi.cn/",
+    de: "https://login.microsoftonline.de/",
+    us: "https://login.microsoftonline.us/",
+};
 export const GuidVariableDescription = "Add a RFC 4122 v4 UUID";
 export const RandomInt = "$randomInt";
 export const RandomIntDescription = "Returns a random integer between min (included) and max (excluded)";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,6 +26,7 @@ export const AzureActiveDirectoryVariableName = "$aadToken";
 export const AzureActiveDirectoryDescription = "Prompts to sign in to Azure AD and adds the token to the request";
 export const AzureActiveDirectoryClientId = "aebc6443-996d-45c2-90f0-388ff96faa56";  // VS Code client id
 export const AzureActiveDirectoryForceNewOption = "new";
+export const AzureActiveDirectoryClearCacheOption = "clear";
 export const AzureClouds = {
     ppe: {
         aad: "https://login.windows-ppe.net/",  // for testing purposes only

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import { CustomVariableReferencesCodeLensProvider } from './customVariableRefere
 import { HttpCodeLensProvider } from './httpCodeLensProvider';
 import { RequestBodyDocumentLinkProvider } from './documentLinkProvider';
 import { HttpDocumentSymbolProvider } from './httpDocumentSymbolProvider';
+import { VariableProcessor } from './variableProcessor';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -44,6 +45,7 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand('rest-client.copy-codesnippet', () => codeSnippetController.copy()));
     context.subscriptions.push(commands.registerCommand('rest-client.copy-request-as-curl', () => codeSnippetController.copyAsCurl()));
     context.subscriptions.push(commands.registerCommand('rest-client.switch-environment', () => environmentController.switchEnvironment()));
+    context.subscriptions.push(commands.registerCommand('rest-client.clear-aad-token-cache', () => VariableProcessor.clearAadTokenCache()));
     context.subscriptions.push(commands.registerCommand('rest-client._openDocumentLink', args => {
         workspace.openTextDocument(Uri.file(args.path)).then(window.showTextDocument, error => {
             window.showErrorMessage(error.message);

--- a/src/httpElementFactory.ts
+++ b/src/httpElementFactory.ts
@@ -104,7 +104,13 @@ export class HttpElementFactory {
             null,
             Constants.RandomIntDescription,
             new SnippetString(`{{$\${name:${Constants.RandomInt.slice(1)}} \${1:min} \${2:max}}}`)));
-
+        originalElements.push(new HttpElement(
+            Constants.AzureActiveDirectoryVariableName,
+            ElementType.SystemVariable,
+            null,
+            Constants.AzureActiveDirectoryDescription,
+            new SnippetString(`{{$\${name:${Constants.AzureActiveDirectoryVariableName.slice(1)}}}}`)));
+    
         // add environment custom variables
         let customVariables = await EnvironmentController.getCustomVariables();
         for (let [variableName, variableValue] of customVariables) {

--- a/src/httpElementFactory.ts
+++ b/src/httpElementFactory.ts
@@ -110,7 +110,7 @@ export class HttpElementFactory {
             null,
             Constants.AzureActiveDirectoryDescription,
             new SnippetString(`{{$\${name:${Constants.AzureActiveDirectoryVariableName.slice(1)}}}}`)));
-    
+
         // add environment custom variables
         let customVariables = await EnvironmentController.getCustomVariables();
         for (let [variableName, variableValue] of customVariables) {

--- a/src/variableProcessor.ts
+++ b/src/variableProcessor.ts
@@ -103,7 +103,7 @@ export class VariableProcessor {
         const promise = new Promise<string>((resolve, reject) => {
             authContext.acquireUserCode(targetApp, clientId, "en-US", (codeError: Error, codeResponse: SignInCode) => {
                 if (codeError) {
-                    window.showErrorMessage(`Sign in failed (new code): ${codeError.message}`, messageBoxOptions);
+                    window.showErrorMessage(`Sign in failed. Please try again.\r\n\r\nStage: acquireUserCode\r\nError: ${codeError.message}`, messageBoxOptions);
                     return reject(codeError);
                 }
 
@@ -120,7 +120,7 @@ export class VariableProcessor {
                     } else if (value == done) {
                         authContext.acquireTokenWithDeviceCode(targetApp, clientId, codeResponse, (tokenError: Error, tokenResponse: SignInToken) => {
                             if (tokenError) {
-                                window.showErrorMessage(`Sign in failed (get token): ${tokenError.message}`, messageBoxOptions);
+                                window.showErrorMessage(`Sign in failed. Please try again.\r\n\r\nStage: acquireTokenWithDeviceCode\r\nError: ${tokenError.message}`, messageBoxOptions);
                                 return reject(tokenError);
                             }
         

--- a/src/variableProcessor.ts
+++ b/src/variableProcessor.ts
@@ -5,9 +5,9 @@ import { EnvironmentController } from './controllers/environmentController';
 import * as Constants from './constants';
 import { Func } from './common/delegates';
 import * as adal from 'adal-node';
-import * as copyPaste from 'copy-paste';
 import * as moment from 'moment';
-import * as uuid from 'node-uuid';
+const copyPaste = require('copy-paste');
+const uuid = require('node-uuid');
 
 const aadRegexPattern = `\\{\\{\\s*\\${Constants.AzureActiveDirectoryVariableName}(\\s+(${Constants.AzureActiveDirectoryForceNewOption}))?(\\s+(ppe|public|cn|de|us))?(\\s+([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))?\\s*\\}\\}`;
 const aadTokenCache = {};
@@ -94,7 +94,7 @@ export class VariableProcessor {
         let forceNewToken = false;
         const groups = new RegExp(aadRegexPattern).exec(url);
         if (groups) {
-            forceNewToken = (groups[2] === Constants.AzureActiveDirectoryForceNewOption);
+            forceNewToken = groups[2] === Constants.AzureActiveDirectoryForceNewOption;
             cloud = groups[4] || cloud;
             tenantId = groups[6] || tenantId;
         }

--- a/src/variableProcessor.ts
+++ b/src/variableProcessor.ts
@@ -108,7 +108,7 @@ export class VariableProcessor {
                 }
 
                 const prompt1 = `Sign in to Azure AD with the following code (will be copied to the clipboard) to add a token to your request.\r\n\r\nCode: ${codeResponse.userCode}`;
-                const prompt2 = `Code copied to the clipboard. Confirm when signed in.\r\n\r\nCode: ${codeResponse.userCode}`;
+                const prompt2 = `Azure AD verification page opened in default browser. Paste code to complete sign in (already copied to the clipboard) and confirm when done. Token will be copied to the clipboard when done.\r\n\r\nCode: ${codeResponse.userCode}`;
                 const signIn = "Sign in";
                 const tryAgain = "Try again";
                 const done = "Done";
@@ -123,8 +123,10 @@ export class VariableProcessor {
                                 window.showErrorMessage(`Sign in failed. Please try again.\r\n\r\nStage: acquireTokenWithDeviceCode\r\nError: ${tokenError.message}`, messageBoxOptions);
                                 return reject(tokenError);
                             }
-        
-                            resolve(tokenResponse ? `${tokenResponse.tokenType} ${tokenResponse.accessToken}` : null);
+                            
+                            const token = tokenResponse ? `${tokenResponse.tokenType} ${tokenResponse.accessToken}` : null;
+                            copyPaste.copy(token);
+                            resolve(token);
                         });
                     } else {
                         return reject("Cancelled");

--- a/src/variableProcessor.ts
+++ b/src/variableProcessor.ts
@@ -1,11 +1,47 @@
 'use strict';
 
-import { window } from 'vscode';
+import { commands, Uri, window } from 'vscode';
 import { EnvironmentController } from './controllers/environmentController';
 import * as Constants from './constants';
 import { Func } from './common/delegates';
 import * as moment from 'moment';
 const uuid = require('node-uuid');
+const adal = require('adal-node');
+const copyPaste = require('copy-paste');
+
+// see UserCodeInfo at https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/blob/dev/lib/adal.d.ts
+interface SignInCode {
+    deviceCode: string;
+    expiresIn: number;
+    interval: number;
+    message: string;
+    userCode: string;
+    verificationUrl: string;
+    error?: any;
+    errorDescription?: any;
+    [x: string]: any;
+}
+
+// see TokenResponse at https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/blob/dev/lib/adal.d.ts
+interface SignInToken {
+    tokenType: string;
+    expiresIn: number;
+    expiresOn: Date | string;
+    resource: string;
+    accessToken: string;
+    refreshToken?: string;
+    createdOn?: Date | string;
+    userId?: string;
+    isUserIdDisplayable?: boolean;
+    tenantId?: string;
+    oid?: string;
+    givenName?: string;
+    familyName?: string;
+    identityProvider?: string;
+    error?: any;
+    errorDescription?: any;
+    [x: string]: any;
+}
 
 export class VariableProcessor {
 
@@ -22,6 +58,12 @@ export class VariableProcessor {
             if (regex.test(request)) {
                 request = request.replace(regex, globalVariables[variablePattern]);
             }
+        }
+
+        // special-casing AAD token since it's the only variable that requires a promise
+        let regex = new RegExp(`\\{\\{\\s*\\${Constants.AzureActiveDirectoryVariableName}\\s*\\}\\}`, 'g');
+        if (regex.test(request)) {
+            request = request.replace(regex, await VariableProcessor.getAadToken(request));
         }
 
         let fileVariables = VariableProcessor.getCustomVariablesInCurrentFile();
@@ -41,6 +83,62 @@ export class VariableProcessor {
         }
 
         return request;
+    }
+
+    public static async getAadToken(url: string): Promise<string> {
+        // get target app from URL
+        const targetApp = (new RegExp('^[^\\s]+\\s+([^:]*:///?[^/]*/)').exec(url) || [url])[1];
+
+        // get the target cloud sign-in URL
+        const tld = targetApp.substring(targetApp.lastIndexOf(".") + 1, targetApp.length - 1);
+        const endpoint = Constants.AzureActiveDirectorySignInUrls[tld] || Constants.AzureActiveDirectorySignInUrls.public;
+
+        const tenantId = "common";
+        const signInUrl = `${endpoint}${tenantId}`;
+        const authContext: any = new adal.AuthenticationContext(signInUrl);
+
+        const clientId = Constants.AzureActiveDirectoryClientId;
+        const messageBoxOptions = { modal: true };
+        
+        const promise = new Promise<string>((resolve, reject) => {
+            authContext.acquireUserCode(targetApp, clientId, "en-US", (codeError: Error, codeResponse: SignInCode) => {
+                if (codeError) {
+                    window.showErrorMessage(`Sign in failed (new code): ${codeError.message}`, messageBoxOptions);
+                    return reject(codeError);
+                }
+
+                const prompt1 = `Sign in to Azure AD with the following code (will be copied to the clipboard) to add a token to your request.\r\n\r\nCode: ${codeResponse.userCode}`;
+                const prompt2 = `Code copied to the clipboard. Confirm when signed in.\r\n\r\nCode: ${codeResponse.userCode}`;
+                const signIn = "Sign in";
+                const tryAgain = "Try again";
+                const done = "Done";
+                const signInPrompt = value => {
+                    if (value == signIn || value == tryAgain) {
+                        copyPaste.copy(codeResponse.userCode);
+                        commands.executeCommand('vscode.open', Uri.parse(codeResponse.verificationUrl));
+                        window.showInformationMessage(prompt2, messageBoxOptions, done, tryAgain).then(signInPrompt);
+                    } else if (value == done) {
+                        authContext.acquireTokenWithDeviceCode(targetApp, clientId, codeResponse, (tokenError: Error, tokenResponse: SignInToken) => {
+                            if (tokenError) {
+                                window.showErrorMessage(`Sign in failed (get token): ${tokenError.message}`, messageBoxOptions);
+                                return reject(tokenError);
+                            }
+        
+                            resolve(tokenResponse ? `${tokenResponse.tokenType} ${tokenResponse.accessToken}` : null);
+                        });
+                    } else {
+                        return reject("Cancelled");
+                    }
+                };
+                window.showInformationMessage(prompt1, messageBoxOptions, signIn).then(signInPrompt);
+            });
+        });
+        
+        promise.catch(error => {
+            console.error(error);
+        });
+        
+        return promise;
     }
 
     public static getGlobalVariables(): { [key: string]: Func<string, string> } {

--- a/src/variableProcessor.ts
+++ b/src/variableProcessor.ts
@@ -45,7 +45,7 @@ export class VariableProcessor {
             }
         }
 
-        // promise-based variables using URL-inspection must be last
+        // any vars that make decisions on the URL (request var) must be last so all vars have been evaluated
         let aadRegex = new RegExp(aadRegexPattern, 'g');
         if (aadRegex.test(request)) {
             request = request.replace(aadRegex, await VariableProcessor.getAadToken(request));

--- a/src/variableProcessor.ts
+++ b/src/variableProcessor.ts
@@ -9,7 +9,7 @@ const uuid = require('node-uuid');
 const adal = require('adal-node');
 const copyPaste = require('copy-paste');
 
-const aadRegexPattern = `\\{\\{\\s*\\${Constants.AzureActiveDirectoryVariableName}(\\s*|\\s+([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))\\}\\}`;
+const aadRegexPattern = `\\{\\{\\s*\\${Constants.AzureActiveDirectoryVariableName}(\\s*|\\s+([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))\\}\\}`;
 
 // see UserCodeInfo at https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/blob/dev/lib/adal.d.ts
 interface SignInCode {

--- a/test/aadToken.http
+++ b/test/aadToken.http
@@ -24,7 +24,11 @@ Authorization: {{$aadToken f884863f-04ce-4326-b064-dfbc608f0dd2}}
 ###
 // Explicit directory using domain name
 GET {{arm}}/subscriptions?api-version=2017-08-01
-Authorization: {{$aadToken dreamsparkuser1outlook.onmicrosoft.com}}
+Authorization: {{$aadToken clear dreamsparkuser1outlook.onmicrosoft.com}}
+###
+// Explicit directory using tenant ID -- should reuse domain-based token
+GET {{arm}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken f884863f-04ce-4326-b064-dfbc608f0dd2}}
 ###
 // Do not reuse older token -- force re-authentication (e.g. switch account)
 GET {{arm}}/subscriptions?api-version=2017-08-01
@@ -59,4 +63,7 @@ Authorization: {{$aadToken us}}
 // Explicit cloud selection -- ppe
 GET {{arm-ppe}}/subscriptions?api-version=2017-08-01
 Authorization: {{$aadToken ppe}}
+###
+// Clear AAD token cache (will cause an invalid URI error, but the token cache will be cleared)
+{{$aadToken clear}}
 ###

--- a/test/aadToken.http
+++ b/test/aadToken.http
@@ -22,9 +22,11 @@ Authorization: {{$aadToken}}
 GET {{arm}}/subscriptions?api-version=2017-08-01
 Authorization: {{$aadToken f884863f-04ce-4326-b064-dfbc608f0dd2}}
 ###
+// Restart Code to clear the token cache before continuing -- next 2 tests cover saving the tenant id when starting with a domain
+###
 // Explicit directory using domain name
 GET {{arm}}/subscriptions?api-version=2017-08-01
-Authorization: {{$aadToken clear dreamsparkuser1outlook.onmicrosoft.com}}
+Authorization: {{$aadToken dreamsparkuser1outlook.onmicrosoft.com}}
 ###
 // Explicit directory using tenant ID -- should reuse domain-based token
 GET {{arm}}/subscriptions?api-version=2017-08-01
@@ -63,7 +65,4 @@ Authorization: {{$aadToken us}}
 // Explicit cloud selection -- ppe
 GET {{arm-ppe}}/subscriptions?api-version=2017-08-01
 Authorization: {{$aadToken ppe}}
-###
-// Clear AAD token cache (will cause an invalid URI error, but the token cache will be cleared)
-{{$aadToken clear}}
 ###

--- a/test/tests.http
+++ b/test/tests.http
@@ -1,0 +1,62 @@
+@arm = https://management.azure.com
+@graph = https://graph.windows.net
+
+@arm-cn = https://management.chinacloudapi.cn
+@graph-cn = https://graph.chinacloudapi.cn
+
+@arm-de = https://management.microsoftazure.de
+@graph-de = https://graph.cloudapi.de
+
+@arm-us = https://management.usgovcloudapi.net
+@graph-us = https://graph.windows.net
+
+@arm-ppe = https://api-dogfood.resources.windows-int.net
+@graph-ppe = https://graph.ppe.windows.net
+
+###
+// Use the default directory for the account
+GET {{arm}}/tenants?api-version=2017-08-01
+Authorization: {{$aadToken}}
+###
+// Explicit directory using tenant ID
+GET {{arm}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken f884863f-04ce-4326-b064-dfbc608f0dd2}}
+###
+// Explicit directory using domain name
+GET {{arm}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken dreamsparkuser1outlook.onmicrosoft.com}}
+###
+// Do not reuse older token -- force re-authentication (e.g. switch account)
+GET {{arm}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken new dreamsparkuser1outlook.onmicrosoft.com}}
+###
+// Implicit cloud selection (via REST endpoint TLD) -- cn
+// TODO: FAILED!!!
+GET {{arm-cn}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken}}
+###
+// Implicit cloud selection (via REST endpoint TLD) -- de
+GET {{arm-de}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken}}
+###
+// Explicit cloud selection -- public
+GET {{arm}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken public}}
+###
+// Explicit cloud selection -- cn
+// TODO: FAILED!!!
+GET {{arm-cn}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken new cn bbedd486-2c6a-4208-a2df-56f43cc823aa}}
+###
+// Explicit cloud selection -- de
+GET {{arm-de}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken de}}
+###
+// Explicit cloud selection -- us
+GET {{arm-us}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken us}}
+###
+// Explicit cloud selection -- ppe
+GET {{arm-ppe}}/subscriptions?api-version=2017-08-01
+Authorization: {{$aadToken ppe}}
+###


### PR DESCRIPTION
No more copying AAD tokens from the portal or other sources :-)
**`{{$aadToken}}`** &ndash; Get token for home directory of the signed-in user
**`{{$aadToken 00000000-0000-0000-0000-000000000000}}`** &ndash; Get token for directory using tenant ID
**`{{$aadToken contoso.com}}`** &ndash; Get token for directory using domain
**`{{$aadToken new contoso.com}}`** &ndash; Force re-auth and don't reuse tokens across requests
**`{{$aadToken public|cn|de|us|ppe}}`** &ndash; Get token for specific cloud (otherwise implied from URL)
**`F1 > Rest Client: Clear AAD token cache`** &ndash; Clear the in-memory token cache (or restart Code)