### PR TITLE
[Document Link Provider] Adding Visual Studio Live Share support

### DIFF
--- a/src/documentLinkProvider.ts
+++ b/src/documentLinkProvider.ts
@@ -11,7 +11,7 @@ export class RequestBodyDocumentLinkProvider implements DocumentLinkProvider {
 
     public provideDocumentLinks(document: TextDocument, _token: CancellationToken): DocumentLink[] {
         const results: DocumentLink[] = [];
-        const base = path.dirname(document.uri.fsPath);
+        const base = path.dirname(document.uri.toString());
         const text = document.getText();
 
         let lines: string[] = text.split(/\r?\n/g);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -45,7 +45,7 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand('rest-client.switch-environment', () => environmentController.switchEnvironment()));
     context.subscriptions.push(commands.registerCommand('rest-client.clear-aad-token-cache', () => VariableProcessor.clearAadTokenCache()));
     context.subscriptions.push(commands.registerCommand('rest-client._openDocumentLink', args => {
-        workspace.openTextDocument(Uri.file(args.path)).then(window.showTextDocument, error => {
+        workspace.openTextDocument(Uri.parse(args.path)).then(window.showTextDocument, error => {
             window.showErrorMessage(error.message);
         });
     }));

--- a/src/workspaceUtility.ts
+++ b/src/workspaceUtility.ts
@@ -9,7 +9,7 @@ export function getWorkspaceRootPath(): string {
         let fileUri = window.activeTextEditor.document.uri;
         let workspaceFolder = workspace.getWorkspaceFolder(fileUri);
         if (workspaceFolder) {
-            return workspaceFolder.uri.fsPath;
+            return workspaceFolder.uri.toString();
         }
     }
 }


### PR DESCRIPTION
This PR adds support for [Visual Studio Live Share](http://aka.ms/vsls) to the document link provider, by ensuring that URI construction is done using the VS Code APIs which preserve the correct scheme. This is necessary because "guests" within a Live Share session see remote files using the `vsls:` scheme, whereas the the host (and non-Live Share users) sees files using the `file:` scheme. Therefore, this change preserves the existing behavior, while allowing REST Client users to click on `< foo.js` links within the context of a collaboration session 🚀 Specifically, this PR makes the following two changes:

1. Use `Uri.toString()` as opposed to `Uri.fsPath`, since the later strips the `Uri`'s scheme, which removes the `vsls:` portion that is critical for Live Share.

2. Use `Uri.parse()` as opposed to `Uri.file()`, since the later always appends the `file://` scheme to the parse `Uri`, as opposed to parsing the provided string, and respecting its scheme (if there is one)

VS Live Share + REST Client integration is already really great, since the "host" can share a locally running REST API, and the "guest" can then author requests against it (see [this video](https://www.youtube.com/watch?v=fcpGS8M0niY)). This PR extends that experience by making sure the document links work for all participants in a collaboration session.

// CC @Huachao 