### PR TITLE
Fix bug to exclude hosts(with port) for proxy

### DIFF
--- a/src/httpClient.ts
+++ b/src/httpClient.ts
@@ -257,7 +257,7 @@ export class HttpClient {
                 // if port specified, match host without port or hostname:port exactly match
                 let [ph, pp] = urlParts;
                 if (ph === hostName && (!pp || pp === port)) {
-                    return true
+                    return true;
                 }
             }
         }


### PR DESCRIPTION
Only the first one in ignore host(with port) take effect in "rest-client.excludeHostsForProxy".