### PR TITLE
[Live Share] Limiting linting to local files

### DIFF
--- a/src/variableDiagnosticsProvider.ts
+++ b/src/variableDiagnosticsProvider.ts
@@ -35,7 +35,7 @@ export class VariableDiagnosticsProvider {
     }
 
     public async checkVariables(document: TextDocument) {
-        if (document.languageId !== 'http') {
+        if (document.languageId !== 'http' || document.uri.scheme !== 'file') {
             return;
         }
 


### PR DESCRIPTION
This is a follow-up to #187, since I forgot to limit the variable linting to local files as well, and Live Share handles "remoting" diagnostics from the host to the guest.

// CC @Huachao 