### PR TITLE
Do not add Host header if url already has one

### DIFF
--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -83,12 +83,10 @@ export class HttpClient {
 
         // add default headers if not specified
         for (let header in this._settings.defaultHeaders) {
-            if (!hasHeader(options.headers, header)) {
-                if (header !== 'Host' || httpRequest.url[0] === '/') {
-                    const value = this._settings.defaultHeaders[header];
-                    if (value) {
-                        options.headers[header] = value;
-                    }
+            if (!hasHeader(options.headers, header) && (header.toLowerCase() !== 'host' || httpRequest.url[0] === '/')) {
+                const value = this._settings.defaultHeaders[header];
+                if (value) {
+                    options.headers[header] = value;
                 }
             }
         }

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -84,9 +84,11 @@ export class HttpClient {
         // add default headers if not specified
         for (let header in this._settings.defaultHeaders) {
             if (!hasHeader(options.headers, header)) {
-                const value = this._settings.defaultHeaders[header];
-                if (value) {
-                    options.headers[header] = value;
+                if (header !== 'Host' || httpRequest.url[0] === '/') {
+                    const value = this._settings.defaultHeaders[header];
+                    if (value) {
+                        options.headers[header] = value;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hey there! about my previous pull request #206, this is a small bug fix.

While doing `GET http://some.domain` and having a default `Host` header,
it'd add a wrong Host header which wouldn't work for the request in progress.