### PR TITLE
Switch JSON formatting from 'jsonc-parser' to 'js-beautify'

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,11 @@
       "resolved": "http://registry.npm.taobao.org/JSONSelect/download/JSONSelect-0.4.0.tgz",
       "integrity": "sha1-oI7cxn6z/L6Z7WMIVTRKDPKCu40="
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+    },
     "adal-node": {
       "version": "0.1.28",
       "resolved": "http://registry.npm.taobao.org/adal-node/download/adal-node-0.1.28.tgz",
@@ -258,6 +263,11 @@
         "inherits": "2.0.3"
       }
     },
+    "bluebird": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA=="
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "http://registry.npm.taobao.org/brace-expansion/download/brace-expansion-1.1.11.tgz",
@@ -436,6 +446,15 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "config-chain": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.11.tgz",
+      "integrity": "sha1-q6CXR9++TD5w52am5BWG4YWfxvI=",
+      "requires": {
+        "ini": "1.3.5",
+        "proto-list": "1.2.4"
+      }
+    },
     "convert-source-map": {
       "version": "1.5.1",
       "resolved": "http://registry.npm.taobao.org/convert-source-map/download/convert-source-map-1.5.1.tgz",
@@ -559,6 +578,28 @@
       "integrity": "sha1-HFlQAPBKiJffuFAAiSoPTDOvhsM=",
       "requires": {
         "safe-buffer": "5.1.2"
+      }
+    },
+    "editorconfig": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-0.13.3.tgz",
+      "integrity": "sha512-WkjsUNVCu+ITKDj73QDvi0trvpdDWdkDyHybDGSXPfekLCqwmpD7CP7iPbvBgosNuLcI96XTDwNa75JyFl7tEQ==",
+      "requires": {
+        "bluebird": "3.5.1",
+        "commander": "2.17.1",
+        "lru-cache": "3.2.0",
+        "semver": "5.5.0",
+        "sigmund": "1.0.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-3.2.0.tgz",
+          "integrity": "sha1-cXibO39Tmb7IVl3aOKow0qCX7+4=",
+          "requires": {
+            "pseudomap": "1.0.2"
+          }
+        }
       }
     },
     "elegant-spinner": {
@@ -1398,6 +1439,11 @@
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+    },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/invert-kv/download/invert-kv-1.0.0.tgz",
@@ -1607,6 +1653,17 @@
       "requires": {
         "lex-parser": "0.1.4",
         "nomnom": "1.5.2"
+      }
+    },
+    "js-beautify": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.7.5.tgz",
+      "integrity": "sha512-9OhfAqGOrD7hoQBLJMTA+BKuKmoEtTJXzZ7WDF/9gvjtey1koVLuZqIY6c51aPDjbNdNtIXAkiWKVhziawE9Og==",
+      "requires": {
+        "config-chain": "1.1.11",
+        "editorconfig": "0.13.3",
+        "mkdirp": "0.5.1",
+        "nopt": "3.0.6"
       }
     },
     "js-tokens": {
@@ -1979,14 +2036,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "http://registry.npm.taobao.org/minimist/download/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "http://registry.npm.taobao.org/mkdirp/download/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -2095,6 +2150,14 @@
           "resolved": "http://registry.npm.taobao.org/underscore/download/underscore-1.1.7.tgz",
           "integrity": "sha1-QLq4S60Z0jAJbo1u9ii/8FXYPbA="
         }
+      }
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "requires": {
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -2358,6 +2421,11 @@
       "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o=",
       "dev": true
     },
+    "proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
+    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "http://registry.npm.taobao.org/pseudomap/download/pseudomap-1.0.2.tgz",
@@ -2585,6 +2653,11 @@
       "version": "1.0.0",
       "resolved": "http://registry.npm.taobao.org/shebang-regex/download/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA="
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -558,6 +558,7 @@
     "highlight.js": "^9.6.0",
     "httpsnippet": "^1.16.5",
     "iconv-lite": "^0.4.15",
+    "js-beautify": "^1.7.5",
     "jsonc-parser": "^1.0.3",
     "jsonpath": "^1.0.0",
     "mime-types": "^2.1.14",

--- a/src/utils/responseFormatUtility.ts
+++ b/src/utils/responseFormatUtility.ts
@@ -1,18 +1,16 @@
 'use strict';
 
-import { applyEdits, format as JSONFormat } from "jsonc-parser/lib/umd/main";
-import { EOL } from "os";
 import { window } from 'vscode';
 import { MimeUtility } from './mimeUtility';
 const pd = require('pretty-data').pd;
+const beautify = require('js-beautify').js_beautify
 
 export class ResponseFormatUtility {
     public static formatBody(body: string, contentType: string, suppressValidation: boolean): string {
         if (contentType) {
             if (MimeUtility.isJSON(contentType)) {
                 if (ResponseFormatUtility.IsJsonString(body)) {
-                    const edits = JSONFormat(body, undefined, { tabSize: 2, insertSpaces: true, eol: EOL });
-                    body = applyEdits(body, edits);
+                    body = beautify(body, { indent_size: 4 })
                 } else if (!suppressValidation) {
                     window.showWarningMessage('The content type of response is application/json, while response body is not a valid json string');
                 }


### PR DESCRIPTION
The existing responseFormatUtility.ts makes use of 'jsonc-parser' to format incoming JSON. The speed doesn't vary much based on size of JSON, but it **does** vary depending on the number of "edits" that need to be made. When the current implementation tries to format JSON with many objects and sub objects, 30+ seconds can go by (and the waiting spinner stalls). 'pretty-data' uses JSON.stringify(JSON.parse)) which is quick, but will break some invalid JSON where a key is listed twice. I have found that 'js-beautify' is quick and acceptable.

I used this link to test, it is both a large JSON payload and one that is slow to format using 'jsonc-parser' (I gave up waiting), returned in seconds with 'js-beautify':  http://www.vizgr.org/historical-events/search.php?format=json&begin_date=-3000000&end_date=20151231&lang=en