### PR TITLE
Custom date formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,9 +453,9 @@ System variables provide a pre-defined set of variables that can be used in any 
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$randomInt min max}}`: Returns a random integer between min (included) and max (excluded)
 * `{{$timestamp [offset option]}}`: Add UTC timestamp of now. You can even specify any date time based on current time in the format `{{$timestamp number option}}`, e.g., to represent 3 hours ago, simply `{{$timestamp -3 h}}`; to represent the day after tomorrow, simply `{{$timestamp 2 d}}`.
-* `{{$datetime rfc1123|iso8601 [offset option]}}`: Add a datetime string in either _ISO8601_ or _RFC1123_ format. You can even specify any date time based on current time similar to `timestamp` like: `{{$datetime iso8601 1 y}}` to represent a year later in _ISO8601_ format.
+* `{{$datetime rfc1123|iso8601|"custom format"|'custom format' [offset option]}}`: Add a datetime string in either _ISO8601_, _RFC1123_ or a custom format. You can even specify a date time relative to the current date similar to `timestamp` like: `{{$datetime iso8601 1 y}}` to represent a year later in _ISO8601_ format. If specifying a custom format, wrap it in single or double quotes like: `{{$datetime "DD-MM-YYYY" 1 y}}`. The date is formatted using moment.js, read [here](https://momentjs.com/docs/#/parsing/string-format/) for information on format strings.
 
-The option string you can specify in `timestamp` and `datetime` are:
+The offset options you can specify in `timestamp` and `datetime` are:
 
 Option | Description
 ------ | -----------
@@ -479,7 +479,8 @@ Date: {{$datetime rfc1123}}
     "request_id": "{{$guid}}",
     "updated_at": "{{$timestamp}}",
     "created_at": "{{$timestamp -1 d}}",
-    "review_count": "{{$randomInt 5, 200}}"
+    "review_count": "{{$randomInt 5, 200}}",
+    "custom_date": "{{$datetime 'YYYY-MM-DD'}}"
 }
 ```
 > More details about `aadToken` (Azure Active Directory Token) can be found on [Wiki](https://github.com/Huachao/vscode-restclient/wiki/Azure-Active-Directory-Authentication-Samples)

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ System variables provide a pre-defined set of variables that can be used in any 
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$randomInt min max}}`: Returns a random integer between min (included) and max (excluded)
 * `{{$timestamp [offset option]}}`: Add UTC timestamp of now. You can even specify any date time based on current time in the format `{{$timestamp number option}}`, e.g., to represent 3 hours ago, simply `{{$timestamp -3 h}}`; to represent the day after tomorrow, simply `{{$timestamp 2 d}}`.
-* `{{$datetime rfc1123|iso8601|"custom format"|'custom format' [offset option]}}`: Add a datetime string in either _ISO8601_, _RFC1123_ or a custom format. You can even specify a date time relative to the current date similar to `timestamp` like: `{{$datetime iso8601 1 y}}` to represent a year later in _ISO8601_ format. If specifying a custom format, wrap it in single or double quotes like: `{{$datetime "DD-MM-YYYY" 1 y}}`. The date is formatted using moment.js, read [here](https://momentjs.com/docs/#/parsing/string-format/) for information on format strings.
+* `{{$datetime rfc1123|iso8601|"custom format"|'custom format' [offset option]}}`: Add a datetime string in either _ISO8601_, _RFC1123_ or a custom display format. You can even specify a date time relative to the current date similar to `timestamp` like: `{{$datetime iso8601 1 y}}` to represent a year later in _ISO8601_ format. If specifying a custom format, wrap it in single or double quotes like: `{{$datetime "DD-MM-YYYY" 1 y}}`. The date is formatted using moment.js, read [here](https://momentjs.com/docs/#/parsing/string-format/) for information on format strings.
 
 The offset options you can specify in `timestamp` and `datetime` are:
 

--- a/src/utils/httpVariableProviders/systemVariableProvider.ts
+++ b/src/utils/httpVariableProviders/systemVariableProvider.ts
@@ -22,7 +22,7 @@ export class SystemVariableProvider implements HttpVariableProvider {
     private readonly resolveFuncs: Map<string, ResolveSystemVariableFunc> = new Map<string, ResolveSystemVariableFunc>();
 
     private readonly timestampRegex: RegExp = new RegExp(`\\${Constants.TimeStampVariableName}(?:\\s(\\-?\\d+)\\s(y|Q|M|w|d|h|m|s|ms))?`);
-    private readonly datetimeRegex: RegExp = new RegExp(`\\${Constants.DateTimeVariableName}\\s(rfc1123|iso8601)(?:\\s(\\-?\\d+)\\s(y|Q|M|w|d|h|m|s|ms))?`);
+    private readonly datetimeRegex: RegExp = new RegExp(`\\${Constants.DateTimeVariableName}\\s(rfc1123|iso8601|\'.*\'|\".*\")(?:\\s(\\-?\\d+)\\s(y|Q|M|w|d|h|m|s|ms))?`);
     private readonly randomIntegerRegex: RegExp = new RegExp(`\\${Constants.RandomIntVariableName}\\s(\\-?\\d+)\\s(\\-?\\d+)`);
 
     private readonly requestUrlRegex: RegExp = /^(?:[^\s]+\s+)([^:]*:\/\/\/?[^/\s]*\/?)/;
@@ -96,7 +96,16 @@ export class SystemVariableProvider implements HttpVariableProvider {
                     date = utc();
                 }
 
-                return { value: type === 'rfc1123' ? date.toString() : date.toISOString() };
+                if (type === 'rfc1123') {
+                    return { value: date.toString() };
+                } else if (type === 'iso8601') {
+                    return { value: date.toISOString() };
+                } else {
+                    const quotesRemoved = type
+                        .slice(0, type.length - 1)
+                        .slice(1);
+                    return { value: date.format(quotesRemoved) };
+                }
             }
 
             return { warning: ResolveWarningMessage.IncorrectDateTimeVariableFormat };

--- a/src/utils/httpVariableProviders/systemVariableProvider.ts
+++ b/src/utils/httpVariableProviders/systemVariableProvider.ts
@@ -22,7 +22,7 @@ export class SystemVariableProvider implements HttpVariableProvider {
     private readonly resolveFuncs: Map<string, ResolveSystemVariableFunc> = new Map<string, ResolveSystemVariableFunc>();
 
     private readonly timestampRegex: RegExp = new RegExp(`\\${Constants.TimeStampVariableName}(?:\\s(\\-?\\d+)\\s(y|Q|M|w|d|h|m|s|ms))?`);
-    private readonly datetimeRegex: RegExp = new RegExp(`\\${Constants.DateTimeVariableName}\\s(rfc1123|iso8601|\'.*\'|\".*\")(?:\\s(\\-?\\d+)\\s(y|Q|M|w|d|h|m|s|ms))?`);
+    private readonly datetimeRegex: RegExp = new RegExp(`\\${Constants.DateTimeVariableName}\\s(rfc1123|iso8601|\'.+\'|\".+\")(?:\\s(\\-?\\d+)\\s(y|Q|M|w|d|h|m|s|ms))?`);
     private readonly randomIntegerRegex: RegExp = new RegExp(`\\${Constants.RandomIntVariableName}\\s(\\-?\\d+)\\s(\\-?\\d+)`);
 
     private readonly requestUrlRegex: RegExp = /^(?:[^\s]+\s+)([^:]*:\/\/\/?[^/\s]*\/?)/;
@@ -101,10 +101,7 @@ export class SystemVariableProvider implements HttpVariableProvider {
                 } else if (type === 'iso8601') {
                     return { value: date.toISOString() };
                 } else {
-                    const quotesRemoved = type
-                        .slice(0, type.length - 1)
-                        .slice(1);
-                    return { value: date.format(quotesRemoved) };
+                    return { value: date.format(type.slice(1, type.length - 2)) };
                 }
             }
 


### PR DESCRIPTION
This PR attempts to add support for the following scenario:

``` json
{
    "custom_date": "{{$datetime 'YYYY-MM-DD'}}"
}
```

I've also updated the README. I haven't made a VS Code extension before so I haven't ran these changes locally. If someone could give me a few pointers or test the branch for me I'd really appreciate it.