### PR TITLE
Allow environment variables to reference shared variables

### DIFF
--- a/src/utils/httpVariableProviders/environmentVariableProvider.ts
+++ b/src/utils/httpVariableProviders/environmentVariableProvider.ts
@@ -65,7 +65,7 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
                 continue;
             }
             const referenceKey = match[1].trim();
-            if (referenceKey in shared && typeof(shared[referenceKey]) === "string") {
+            if (typeof(shared[referenceKey]) === "string") {
                 current[key] = shared[referenceKey];
             }
         }

--- a/src/utils/httpVariableProviders/environmentVariableProvider.ts
+++ b/src/utils/httpVariableProviders/environmentVariableProvider.ts
@@ -54,10 +54,10 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
         return Object.assign({}, sharedEnvironmentVariables, currentEnvironmentVariables);
     }
 
-    private mapEnvironmentVariables(current: any, shared: any){
+    private mapEnvironmentVariables(current: any, shared: any) {
         for (let key in current) {
             const value = current[key];
-            if (!(typeof(value) === "string")) {
+            if (typeof(value) !== "string") {
                 continue;
             }
             const variableRegex = /\{{2}\$shared (.+?)\}{2}/;
@@ -67,7 +67,7 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
             }
             const referenceKey = match[1].trim();
             const referenceValue = shared[referenceKey];
-            if(!referenceValue) {
+            if (!referenceValue && referenceValue !== "") {
                 continue;
             }
             current[key] = referenceValue;

--- a/src/utils/httpVariableProviders/environmentVariableProvider.ts
+++ b/src/utils/httpVariableProviders/environmentVariableProvider.ts
@@ -13,6 +13,7 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
     private readonly _settings: RestClientSettings = RestClientSettings.Instance;
 
     public static get Instance(): EnvironmentVariableProvider {
+
         if (!EnvironmentVariableProvider._instance) {
             EnvironmentVariableProvider._instance = new EnvironmentVariableProvider();
         }
@@ -49,6 +50,27 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
         const variables = this._settings.environmentVariables;
         const currentEnvironmentVariables = variables[environmentName];
         const sharedEnvironmentVariables = variables[EnvironmentController.sharedEnvironmentName];
+        this.mapEnvironmentVariables(currentEnvironmentVariables, sharedEnvironmentVariables);
         return Object.assign({}, sharedEnvironmentVariables, currentEnvironmentVariables);
+    }
+
+    private mapEnvironmentVariables(current: any, shared: any){
+        for (let key in current) {
+            const value = current[key];
+            if (!(typeof(value) === "string")) {
+                continue;
+            }
+            const variableRegex = /\{{2}\$shared (.+?)\}{2}/;
+            const match = variableRegex.exec(value);
+            if (!match) {
+                continue;
+            }
+            const referenceKey = match[1].trim();
+            const referenceValue = shared[referenceKey];
+            if(!referenceValue) {
+                continue;
+            }
+            current[key] = referenceValue;
+        }
     }
 }

--- a/src/utils/httpVariableProviders/environmentVariableProvider.ts
+++ b/src/utils/httpVariableProviders/environmentVariableProvider.ts
@@ -55,8 +55,7 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
     }
 
     private mapEnvironmentVariables(current: any, shared: any) {
-        for (let key in current) {
-            const value = current[key];
+        for (const [key, value] of Object.entries(current)) {
             if (typeof(value) !== "string") {
                 continue;
             }
@@ -66,11 +65,9 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
                 continue;
             }
             const referenceKey = match[1].trim();
-            const referenceValue = shared[referenceKey];
-            if (!referenceValue && referenceValue !== "") {
-                continue;
+            if (referenceKey in shared && typeof(shared[referenceKey]) === "string") {
+                current[key] = shared[referenceKey];
             }
-            current[key] = referenceValue;
         }
     }
 }

--- a/src/utils/httpVariableProviders/environmentVariableProvider.ts
+++ b/src/utils/httpVariableProviders/environmentVariableProvider.ts
@@ -13,7 +13,6 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
     private readonly _settings: RestClientSettings = RestClientSettings.Instance;
 
     public static get Instance(): EnvironmentVariableProvider {
-
         if (!EnvironmentVariableProvider._instance) {
             EnvironmentVariableProvider._instance = new EnvironmentVariableProvider();
         }


### PR DESCRIPTION
Per issue #342, changes environment variable provider to check environment variables for values like {{$shared [xyz]}}, and if found attempts to get shared variable with name [xyz]. 

Added new error for trying to find a shared variable and not finding one. 

Added to README to reflect new functionality. 

This is my first contribution so I'm very open to corrections/advice!