### PR TITLE
Include "from .http and .rest file" in the summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Node CI](https://img.shields.io/github/workflow/status/Huachao/vscode-restclient/Node%20CI)](https://img.shields.io/github/workflow/status/Huachao/vscode-restclient/Node%20CI) [![Join the chat at https://gitter.im/Huachao/vscode-restclient](https://badges.gitter.im/Huachao/vscode-restclient.svg)](https://gitter.im/Huachao/vscode-restclient?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) [![Marketplace Version](https://vsmarketplacebadge.apphb.com/version-short/humao.rest-client.svg)](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) [![Downloads](https://vsmarketplacebadge.apphb.com/downloads/humao.rest-client.svg)](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) [![Installs](https://vsmarketplacebadge.apphb.com/installs/humao.rest-client.svg)](https://marketplace.visualstudio.com/items?itemName=humao.rest-client) [![Rating](https://vsmarketplacebadge.apphb.com/rating/humao.rest-client.svg)](https://marketplace.visualstudio.com/items?itemName=humao.rest-client)
 
-REST Client allows you to send HTTP request and view the response in Visual Studio Code directly.
+REST Client allows you to send HTTP requests from .http and .rest files and view the response in Visual Studio Code directly.
 
 ## Main Features
 * Send/Cancel/Rerun __HTTP request__ in editor and view response in a separate pane with syntax highlight


### PR DESCRIPTION
The README is quite long and the key information on how to get started (.http and .rest file extensions support) is quite far down. I overlooked it at first.