### PR TITLE
Add support for the XDG directory specification

### DIFF
--- a/src/utils/userDataManager.ts
+++ b/src/utils/userDataManager.ts
@@ -13,7 +13,7 @@ function getCachePath(): string {
     }
 
     if (process.env.XDG_CACHE_HOME !== undefined) {
-        return path.join(rootPath, process.env.XDG_CACHE_HOME);
+        return path.join(process.env.XDG_CACHE_HOME, restClientDir);
     }
 
     return rootPath;
@@ -25,7 +25,7 @@ function getConfigPath(): string {
     }
 
     if (process.env.XDG_CONFIG_HOME !== undefined) {
-        return path.join(rootPath, process.env.XDG_CONFIG_HOME);
+        return path.join(process.env.XDG_CONFIG_HOME, restClientDir);
     }
 
     return rootPath;

--- a/src/utils/userDataManager.ts
+++ b/src/utils/userDataManager.ts
@@ -4,30 +4,58 @@ import * as path from 'path';
 import { HistoricalHttpRequest } from '../models/httpRequest';
 import { JsonFileUtility } from './jsonFileUtility';
 
+const restClientDir = 'rest-client';
+const rootPath = path.join(os.homedir(), `.${restClientDir}`);
+
+function getCachePath(): string {
+    if (fs.existsSync(rootPath)) {
+        return rootPath;
+    }
+
+    if (process.env.XDG_CACHE_HOME !== undefined) {
+        return path.join(rootPath, process.env.XDG_CACHE_HOME);
+    }
+
+    return rootPath;
+}
+
+function getConfigPath(): string {
+    if (fs.existsSync(rootPath)) {
+        return rootPath;
+    }
+
+    if (process.env.XDG_CONFIG_HOME !== undefined) {
+        return path.join(rootPath, process.env.XDG_CONFIG_HOME);
+    }
+
+    return rootPath;
+}
+
 export class UserDataManager {
 
     private static readonly historyItemsMaxCount = 50;
 
-    private static readonly rootPath: string = path.join(os.homedir(), '.rest-client');
+    private static readonly cachePath: string = getCachePath();
+    private static readonly configPath: string = getConfigPath();
 
     public static get cookieFilePath() {
-        return path.join(this.rootPath, 'cookie.json');
+        return path.join(this.cachePath, 'cookie.json');
     }
 
     private static get historyFilePath() {
-        return path.join(this.rootPath, 'history.json');
+        return path.join(this.cachePath, 'history.json');
     }
 
     private static get environmentFilePath() {
-        return path.join(this.rootPath, 'environment.json');
+        return path.join(this.configPath, 'environment.json');
     }
 
     private static get responseSaveFolderPath() {
-        return path.join(this.rootPath, 'responses/raw');
+        return path.join(this.cachePath, 'responses/raw');
     }
 
     private static get responseBodySaveFolderPath() {
-        return path.join(this.rootPath, 'responses/body');
+        return path.join(this.cachePath, 'responses/body');
     }
 
     public static async initialize(): Promise<void> {


### PR DESCRIPTION
I am a Linux user.

Linux users hate when people put dotfiles in the HOME folder.

I noticed your awesome extension <3 puts its folder in the HOME folder.

I implemented backwards-compatible support for the XDG directory specification[1].

In the case `~/.rest-client` exists, we continue to use that folder. Otherwise, we use both `XDG_CACHE_HOME/rest-client` and `XDG_CONFIG_HOME/rest-client`.

So in my case as a previous user, I would just delete the current folder, and have the extension use the paths because I have those variables defined, as do most Linux users.

1: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html