### PR TITLE
README.md: update usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Fold/Unfold for request block
 
 ## Usage
-In editor, type an HTTP request as simple as below:
+In the editor create a new file, save it with `.http` extension, then type an HTTP request such as:
 ```http
 https://example.com/comments/1
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Fold/Unfold for request block
 
 ## Usage
-In the editor create a new file, save it with `.http` extension, then type an HTTP request such as:
+In editor, type an HTTP request as simple as below:
 ```http
 https://example.com/comments/1
 ```
@@ -71,7 +71,7 @@ content-type: application/json
     "time": "Wed, 21 Oct 2015 18:27:50 GMT"
 }
 ```
-Once you prepared a request, click the `Send Request` link above the request, or use shortcut `Ctrl+Alt+R`(`Cmd+Alt+R` for macOS), or right-click in the editor and then select `Send Request` in the menu, or press `F1` and then select/type `Rest Client: Send Request`, the response will be previewed in a separate __webview__ panel of Visual Studio Code. If you'd like to use the full power of searching, selecting or manipulating in Visual Studio Code, you can also preview response in __an untitled document__ by setting `rest-client.previewResponseInUntitledDocument` to `true`. Once a request is issued, the waiting spin icon will be displayed in the status bar until the response is received. You can click the spin icon to cancel the request. After that, the icon will be replaced with the total duration and response size.
+Once you prepared a request, click the `Send Request` link above the request (this will appear if the file's language mode is `HTTP`, by default `.http` files are like this), or use shortcut `Ctrl+Alt+R`(`Cmd+Alt+R` for macOS), or right-click in the editor and then select `Send Request` in the menu, or press `F1` and then select/type `Rest Client: Send Request`, the response will be previewed in a separate __webview__ panel of Visual Studio Code. If you'd like to use the full power of searching, selecting or manipulating in Visual Studio Code, you can also preview response in __an untitled document__ by setting `rest-client.previewResponseInUntitledDocument` to `true`. Once a request is issued, the waiting spin icon will be displayed in the status bar until the response is received. You can click the spin icon to cancel the request. After that, the icon will be replaced with the total duration and response size.
 
 You can view the breakdown of the response time when hovering over the total duration in status bar, you could view the duration details of _Socket_, _DNS_, _TCP_, _First Byte_ and _Download_.
 


### PR DESCRIPTION
Mention that the extension only works if the file has .http extension. This was not clear for me when I installed it, needed to figure out from the screenshots.