### PR TITLE
Escape quotes for decodeEscapedUnicodeCharacters

### DIFF
--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -254,7 +254,10 @@ export class HttpClient {
     }
 
     private decodeEscapedUnicodeCharacters(body: string): string {
-        return body.replace(/\\u([\d\w]{4})/gi, (_, g) => String.fromCharCode(parseInt(g, 16)));
+        return body.replace(/\\u([\d\w]{4})/gi, (_, g) => {
+            var char = String.fromCharCode(parseInt(g, 16));
+            return char == '\"' ? "\\\"" : char;
+        });
     }
 
     private getRequestCertificate(requestUrl: string): Certificate | null {

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -255,8 +255,8 @@ export class HttpClient {
 
     private decodeEscapedUnicodeCharacters(body: string): string {
         return body.replace(/\\u([\d\w]{4})/gi, (_, g) => {
-            var char = String.fromCharCode(parseInt(g, 16));
-            return char == '\"' ? "\\\"" : char;
+            const char = String.fromCharCode(parseInt(g, 16));
+            return char === '"' ? "\\\"" : char;
         });
     }
 


### PR DESCRIPTION
Server sends me response as 
```
{
    "text": "\u0022text\u0022"
}
```
My expectation was that decodeEscapedUnicodeCharacters will convert it to
```
{
    "text":"\"text\""
}
```
But result was 
`{"text":""text""}`
with invalid json format errors. 
Curl + jq handles that kind of situation perfectly.

So, small pr to fix that behaviour