### PR TITLE
Fix broken links in JSON responses

### DIFF
--- a/src/views/httpResponseWebview.ts
+++ b/src/views/httpResponseWebview.ts
@@ -217,7 +217,7 @@ export class HttpResponseWebview extends BaseWebview {
         <div>
             ${this.settings.disableAddingHrefLinkForLargeResponse && response.bodySizeInBytes > this.settings.largeResponseBodySizeLimitInMB * 1024 * 1024
                 ? innerHtml
-                : this.addUrlLinks(innerHtml)}
+                : this.addUrlLinks(innerHtml, contentType)}
             <a id="scroll-to-top" role="button" aria-label="scroll to top" title="Scroll To Top"><span class="icon"></span></a>
         </div>
         <script type="text/javascript" src="${panel.webview.asWebviewUri(this.scriptFilePath)}" nonce="${nonce}" charset="UTF-8"></script>
@@ -350,11 +350,15 @@ ${HttpResponseWebview.formatHeaders(response.headers)}`;
         });
     }
 
-    private addUrlLinks(innerHtml: string) {
-        return innerHtml.replace(this.urlRegex, match => {
-            const parsedLink = JSON.parse(`"${match}"`);
-            return `<a href=${parsedLink} target="_blank" rel="noopener noreferrer">${match}</a>`;
-        });
+    private addUrlLinks(innerHtml: string, contentType: string | undefined) {
+        if (MimeUtility.isJSON(contentType)) {
+            return innerHtml.replace(this.urlRegex, match => {
+                const parsedLink = JSON.parse(`"${match}"`);
+                return `<a href=${parsedLink} target="_blank" rel="noopener noreferrer">${match}</a>`;
+            });
+        } else {
+            return innerHtml.replace(this.urlRegex, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+        }
     }
 
     private getFoldingRange(lines: string[]): Map<number, FoldingRange> {

--- a/src/views/httpResponseWebview.ts
+++ b/src/views/httpResponseWebview.ts
@@ -351,7 +351,10 @@ ${HttpResponseWebview.formatHeaders(response.headers)}`;
     }
 
     private addUrlLinks(innerHtml: string) {
-        return innerHtml.replace(this.urlRegex, '<a href="$1" target="_blank" rel="noopener noreferrer">$1</a>');
+        return innerHtml.replace(this.urlRegex, match => {
+            const parsedLink = JSON.parse(`"${match}"`);
+            return `<a href=${parsedLink} target="_blank" rel="noopener noreferrer">${match}</a>`;
+        });
     }
 
     private getFoldingRange(lines: string[]): Map<number, FoldingRange> {


### PR DESCRIPTION
Links inside the a JSON response are not displayed properly because JSON encodes strings.

This fix displays the original url but the underlying link is using the parsed string as the link `href` property.

This is an example JSON response that has this problem:

```
{
  "authenticateURL": "https://example.com/auth?reg_code=XLMKJDK\u0026mso_id=ATT",
  "expires": 1592867389703
}
```

The parsed link should be `https://example.com/auth?reg_code=XLMKJDK&mso_id=ATT`.