### PR TITLE
Proxy improvements (enable excludeHostsForProxy )

### DIFF
--- a/package.json
+++ b/package.json
@@ -371,6 +371,12 @@
           "scope": "resource",
           "description": "Send out anonymous usage data"
         },
+        "rest-client.proxy": {
+          "type": "string",
+          "default": null,
+          "scope": "resource",
+          "description": "The proxy setting to use"
+        },
         "rest-client.excludeHostsForProxy": {
           "type": "array",
           "default": [],
@@ -666,6 +672,7 @@
     "pretty-data": "^0.40.0",
     "tough-cookie": "^3.0.1",
     "tough-cookie-file-store-bugfix": "Huachao/tough-cookie-file-store-bugfix",
+    "tunnel": "0.0.6",
     "uuid": "^3.3.2",
     "xmldom": "^0.1.27",
     "xpath": "^0.0.27",

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -156,7 +156,7 @@ export class RestClientSettings implements IRestClientSettings {
         languages.setLanguageConfiguration('http', { brackets: this.addRequestBodyLineIndentationAroundBrackets ? this.brackets : [] });
 
         const httpSettings = workspace.getConfiguration("http");
-        this.proxy = httpSettings.get<string>('proxy');
+        this.proxy = restClientSettings.get<string>("proxy") ?? httpSettings.get<string>('proxy');
         this.proxyStrictSSL = httpSettings.get<boolean>('proxyStrictSSL', false);
     }
 

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -182,12 +182,10 @@ export class HttpClient {
                     port: Number(proxyEndpoint.port),
                     rejectUnauthorized: this._settings.proxyStrictSSL
                 };
-
-                const ctor = (httpRequest.url.startsWith('http:')
-                    ? await import('http-proxy-agent')
-                    : await import('https-proxy-agent')).default;
-
-                options.agent = new ctor(proxyOptions);
+                const tunnel = (await import('tunnel')).default;
+                const hoh = tunnel.httpOverHttp({ proxy: proxyOptions });
+                const agentOptions: got.AgentOptions = { http: hoh, https: hoh };
+                options.agent = agentOptions;
             }
         }
 


### PR DESCRIPTION

Hello, I love this extension and use everyday!

I noticed two proxy issues, so I tried fixed them.

I thought to fix the two at the same is convenient.
so this PR deal with the both two.


# Summary

* (1) `rest-client.excludeHostsForProxy` doesn't work
* (2)`http.proxy` could affect the whole VSCode
  * Hopefully, I want to set a proxy that affect only this extension (e.g. `rest-client.proxy`)

# Reproducible Environment

* 0.24.1 and master(ceab9394dcec576ea38bcc83d53b086317d87d95)
* OS: OSX / Windows 10
* VSCode: 1.46.1


# (1) `excludeHostsForProxy` doesn't work

Maybe already reported #500




In this case, `excludeHostsForProxy` doesn't work.
```
(settings)
"http.proxy": "http://aaa.bbb.com:8888",
"rest-client.excludeHostsForProxy": ["httpbin.org"]

----
GET https://httpbin.org/get

```

I debugged and finally discovered, this "set proxy" block doesn't work.

https://github.com/Huachao/vscode-restclient/blob/master/src/utils/httpClient.ts#L176-L191

Even if you delete the 15 lines, `http.proxy` works, and `excludeHostsForProxy` doesn't work.

I changed the code to use tunnel that follows Got's example.

https://github.com/sindresorhus/got#proxies

# (2)`http.proxy` could affect the whole VSCode

Hopefully, if there is a configuration that affects only this extension, that's really useful.

Because `http.proxy` is a VSCode's configuration that could affect everywhere.

I tried adding `rest-client.proxy`.



# Examples

## Current version (0.24.1)

`excludeHostsForProxy` doesn't work.

```
{
  "http.proxy": "http://aaa.bbb.com:8888",
  "rest-client.excludeHostsForProxy": [
    "httpbin.org"
  ]
}
```


## This PR version

`excludeHostsForProxy` works.
When calling httpbin.org, the proxy is not used.

```
{
  "http.proxy": "http://aaa.bbb.com:8888",
  "rest-client.excludeHostsForProxy": [
    "httpbin.org"
  ]
}

```


This also works.

```
{
  "rest-client.proxy": "http://aaa.bbb.com:8888"
  "rest-client.excludeHostsForProxy": [
    "httpbin.org"
  ]
}
```

