### PR TITLE
Add codelens provider to show current environment next to "Send Request" button

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,7 @@ import { EnvironmentOrFileVariableHoverProvider } from './providers/environmentO
 import { FileVariableDefinitionProvider } from './providers/fileVariableDefinitionProvider';
 import { FileVariableReferenceProvider } from './providers/fileVariableReferenceProvider';
 import { FileVariableReferencesCodeLensProvider } from './providers/fileVariableReferencesCodeLensProvider';
+import { EnvironmentCodeLensProvider } from './providers/EnvironmentCodeLensProvider';
 import { HttpCodeLensProvider } from './providers/httpCodeLensProvider';
 import { HttpCompletionItemProvider } from './providers/httpCompletionItemProvider';
 import { HttpDocumentSymbolProvider } from './providers/httpDocumentSymbolProvider';
@@ -59,6 +60,9 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(languages.registerCompletionItemProvider(documentSelector, new RequestVariableCompletionItemProvider(), '.'));
     context.subscriptions.push(languages.registerHoverProvider(documentSelector, new EnvironmentOrFileVariableHoverProvider()));
     context.subscriptions.push(languages.registerHoverProvider(documentSelector, new RequestVariableHoverProvider()));
+    context.subscriptions.push(new ConfigurationDependentRegistration(
+        () => languages.registerCodeLensProvider(documentSelector, new EnvironmentCodeLensProvider()),
+        s => s.enableSendRequestCodeLens));
     context.subscriptions.push(
         new ConfigurationDependentRegistration(
             () => languages.registerCodeLensProvider(documentSelector, new HttpCodeLensProvider()),

--- a/src/providers/environmentCodeLensProvider.ts
+++ b/src/providers/environmentCodeLensProvider.ts
@@ -1,0 +1,30 @@
+import { CancellationToken, CodeLens, CodeLensProvider, Command, Range, TextDocument, Event } from 'vscode';
+import * as Constants from '../common/constants';
+import { Selector } from '../utils/selector';
+import { EnvironmentController } from '../controllers/environmentController';
+
+export class EnvironmentCodeLensProvider implements CodeLensProvider {   
+
+    readonly onDidChangeCodeLenses = EnvironmentController.onDidChangeEnvironment as unknown as Event<void>;
+
+    public async provideCodeLenses(document: TextDocument, token: CancellationToken): Promise<CodeLens[]> {
+        const blocks: CodeLens[] = [];
+        const lines: string[] = document.getText().split(Constants.LineSplitterRegex);
+        const requestRanges: [number, number][] = Selector.getRequestRanges(lines);
+
+        const environment = await EnvironmentController.getCurrentEnvironment(); 
+        const title = `Environment: ${environment.label}`
+
+        for (const [blockStart, blockEnd] of requestRanges) {
+            const range = new Range(blockStart, 0, blockEnd, 0);
+            const cmd: Command = {
+                arguments: [document, range],
+                title: title,
+                command: 'rest-client.switch-environment'
+            };
+            blocks.push(new CodeLens(range, cmd));
+        }
+
+        return Promise.resolve(blocks);
+    }
+}


### PR DESCRIPTION
This is my first time offering a pull request, I have tried to maintain the same styles as the project. 
I have made the view dependent on the same setting as sending the request via codelens. Could add a different setting for this if you think that would be better.