### PR TITLE
Import requests document from postman collection.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -469,6 +469,11 @@
       "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
       "dev": true
     },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
+    },
     "array-unique": {
       "version": "0.3.2",
       "resolved": "https://registry.npm.taobao.org/array-unique/download/array-unique-0.3.2.tgz",
@@ -1017,6 +1022,11 @@
         "supports-color": "^2.0.0"
       }
     },
+    "charset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/charset/-/charset-1.0.1.tgz",
+      "integrity": "sha512-6dVyOOYjpfFcL1Y4qChrAoQLRHvj2ziyhcm0QJlhOcAhykL/k1kTUPbeo+87MNRTRdk2OIIsIXbuF3x2wi5EXg=="
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npm.taobao.org/chokidar/download/chokidar-2.1.8.tgz?cache=0&sync_timestamp=1587911196018&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fchokidar%2Fdownload%2Fchokidar-2.1.8.tgz",
@@ -1163,7 +1173,6 @@
       "version": "1.9.2",
       "resolved": "http://registry.npm.taobao.org/color-convert/download/color-convert-1.9.2.tgz",
       "integrity": "sha1-SYgbj7pn3xKpa98/VsCqueeRMUc=",
-      "dev": true,
       "requires": {
         "color-name": "1.1.1"
       }
@@ -1171,8 +1180,7 @@
     "color-name": {
       "version": "1.1.1",
       "resolved": "http://registry.npm.taobao.org/color-name/download/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
-      "dev": true
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
     },
     "combined-stream": {
       "version": "1.0.6",
@@ -1489,11 +1497,54 @@
         }
       }
     },
+    "dom-serializer": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+      "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domelementtype": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
+          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+        },
+        "entities": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+          "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ=="
+        }
+      }
+    },
     "domain-browser": {
       "version": "1.2.0",
       "resolved": "http://registry.npm.taobao.org/domain-browser/download/domain-browser-1.2.0.tgz",
       "integrity": "sha1-PTH1AZGmdJ3RN1p/Ui6CPULlTto=",
       "dev": true
+    },
+    "domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
+    },
+    "domhandler": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
+      "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
+      "requires": {
+        "domelementtype": "1"
+      }
+    },
+    "domutils": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
+      "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
+      "requires": {
+        "dom-serializer": "0",
+        "domelementtype": "1"
+      }
     },
     "dotenv": {
       "version": "8.2.0",
@@ -1599,6 +1650,11 @@
         "tapable": "^1.0.0"
       }
     },
+    "entities": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "http://registry.npm.taobao.org/errno/download/errno-0.1.7.tgz",
@@ -1650,6 +1706,11 @@
       "requires": {
         "es6-promise": "^4.0.3"
       }
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -1848,6 +1909,11 @@
       "resolved": "http://registry.npm.taobao.org/extsprintf/download/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "faker": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-4.1.0.tgz",
+      "integrity": "sha1-HkW7vsxndLPBlfrSg1EJxtdIzD8="
+    },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "http://registry.npm.taobao.org/fast-deep-equal/download/fast-deep-equal-1.1.0.tgz",
@@ -1863,6 +1929,11 @@
       "resolved": "https://registry.npm.taobao.org/figgy-pudding/download/figgy-pudding-3.5.2.tgz",
       "integrity": "sha1-tO7oFIq7Adzx0aw0Nn1Z4S+mHW4=",
       "dev": true
+    },
+    "file-type": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-3.9.0.tgz",
+      "integrity": "sha1-JXoHg4TR24CHvESdEH1SpSZyuek="
     },
     "file-uri-to-path": {
       "version": "1.0.0",
@@ -2211,8 +2282,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npm.taobao.org/has-flag/download/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -2348,6 +2418,31 @@
         "minimalistic-crypto-utils": "^1.0.1"
       }
     },
+    "htmlparser2": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
+      "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+      "requires": {
+        "domelementtype": "^1.3.1",
+        "domhandler": "^2.3.0",
+        "domutils": "^1.5.1",
+        "entities": "^1.1.1",
+        "inherits": "^2.0.1",
+        "readable-stream": "^3.1.1"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
+      }
+    },
     "http-cache-semantics": {
       "version": "4.0.3",
       "resolved": "https://registry.npm.taobao.org/http-cache-semantics/download/http-cache-semantics-4.0.3.tgz",
@@ -2371,6 +2466,11 @@
           }
         }
       }
+    },
+    "http-reasons": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/http-reasons/-/http-reasons-0.1.0.tgz",
+      "integrity": "sha1-qVPKZwB4Zp3eFCzomUAbnW6F07Q="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -2566,8 +2666,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "http://registry.npm.taobao.org/inherits/download/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "interpret": {
       "version": "1.2.0",
@@ -2946,6 +3045,11 @@
         "invert-kv": "^2.0.0"
       }
     },
+    "liquid-json": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/liquid-json/-/liquid-json-0.3.1.tgz",
+      "integrity": "sha1-kVWhgTbYprJhXl8W+aJEira1Duo="
+    },
     "loader-runner": {
       "version": "2.4.0",
       "resolved": "https://registry.npm.taobao.org/loader-runner/download/loader-runner-2.4.0.tgz?cache=0&sync_timestamp=1574712098491&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Floader-runner%2Fdownload%2Floader-runner-2.4.0.tgz",
@@ -2977,6 +3081,31 @@
       "version": "4.17.19",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
       "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
+    },
+    "lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha1-ZHYsSGGAglGKw99Mz11YhtriA0c="
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
+    },
+    "lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+    },
+    "lodash.mergewith": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz",
+      "integrity": "sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ=="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -3079,6 +3208,11 @@
         "object-visit": "^1.0.0"
       }
     },
+    "marked": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-1.1.1.tgz",
+      "integrity": "sha512-mJzT8D2yPxoPh7h0UXkB+dBj4FykPJ2OIfxAWeIHrvoHDkFxukV/29QxoFQoPM6RLEwhIFdJpmKBlqVM3s2ZIw=="
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "http://registry.npm.taobao.org/md5.js/download/md5.js-1.3.5.tgz",
@@ -3154,6 +3288,14 @@
       "version": "1.35.0",
       "resolved": "http://registry.npm.taobao.org/mime-db/download/mime-db-1.35.0.tgz",
       "integrity": "sha1-BWnWV0ZkkSg3CWY603mpm5DZq0c="
+    },
+    "mime-format": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mime-format/-/mime-format-2.0.0.tgz",
+      "integrity": "sha1-4p+IkeKE14JwJG8AUNaDS9u+EzI=",
+      "requires": {
+        "charset": "^1.0.0"
+      }
     },
     "mime-types": {
       "version": "2.1.19",
@@ -3605,8 +3747,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "http://registry.npm.taobao.org/number-is-nan/download/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -3978,6 +4119,124 @@
       "resolved": "http://registry.npm.taobao.org/posix-character-classes/download/posix-character-classes-0.1.1.tgz",
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
+    },
+    "postcss": {
+      "version": "7.0.32",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "requires": {
+        "chalk": "^2.4.2",
+        "source-map": "^0.6.1",
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
+    "postman-collection": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/postman-collection/-/postman-collection-3.6.5.tgz",
+      "integrity": "sha512-MoYK32gurXvgXrRuXQ8Xl8vCfRlMJjJX8UCzpXGvl1tQU4NBzVwO83vY1+6P70l4WBU4q0ibDTuahVpXEt/ZbA==",
+      "requires": {
+        "escape-html": "1.0.3",
+        "faker": "4.1.0",
+        "file-type": "3.9.0",
+        "http-reasons": "0.1.0",
+        "iconv-lite": "0.6.2",
+        "liquid-json": "0.3.1",
+        "lodash": "4.17.19",
+        "marked": "1.1.1",
+        "mime-format": "2.0.0",
+        "mime-types": "2.1.27",
+        "postman-url-encoder": "2.1.3",
+        "sanitize-html": "1.20.1",
+        "semver": "7.3.2",
+        "uuid": "3.4.0"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.2",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+          "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        },
+        "mime-db": {
+          "version": "1.44.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.44.0.tgz",
+          "integrity": "sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg=="
+        },
+        "mime-types": {
+          "version": "2.1.27",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.27.tgz",
+          "integrity": "sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==",
+          "requires": {
+            "mime-db": "1.44.0"
+          }
+        },
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        }
+      }
+    },
+    "postman-url-encoder": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-2.1.3.tgz",
+      "integrity": "sha512-CwQjnoxaugCGeOyzVeZ4k1cNQ6iS8OBCzuWzcf4kLStKeRp0MwmLKYv25frynmDpugUUimq/d+FZCq6GtIX9Ag==",
+      "requires": {
+        "postman-collection": "^3.6.4",
+        "punycode": "^2.1.1"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        }
+      }
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -4351,6 +4610,51 @@
       "resolved": "http://registry.npm.taobao.org/safer-buffer/download/safer-buffer-2.1.2.tgz",
       "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
     },
+    "sanitize-html": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.20.1.tgz",
+      "integrity": "sha512-txnH8TQjaQvg2Q0HY06G6CDJLVYCpbnxrdO0WN8gjCKaU5J0KbyGYhZxx5QJg3WLZ1lB7XU9kDkfrCXUozqptA==",
+      "requires": {
+        "chalk": "^2.4.1",
+        "htmlparser2": "^3.10.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.mergewith": "^4.6.1",
+        "postcss": "^7.0.5",
+        "srcset": "^1.0.0",
+        "xtend": "^4.0.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "schema-utils": {
       "version": "1.0.0",
       "resolved": "https://registry.npm.taobao.org/schema-utils/download/schema-utils-1.0.0.tgz?cache=0&sync_timestamp=1587138145115&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fschema-utils%2Fdownload%2Fschema-utils-1.0.0.tgz",
@@ -4599,8 +4903,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npm.taobao.org/source-map/download/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
-      "dev": true
+      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM="
     },
     "source-map-resolve": {
       "version": "0.5.2",
@@ -4674,6 +4977,15 @@
       "resolved": "http://registry.npm.taobao.org/sprintf-js/download/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "srcset": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/srcset/-/srcset-1.0.0.tgz",
+      "integrity": "sha1-pWad4StC87HV6D7QPHEEb8SPQe8=",
+      "requires": {
+        "array-uniq": "^1.0.2",
+        "number-is-nan": "^1.0.0"
+      }
     },
     "sshpk": {
       "version": "1.14.2",
@@ -4819,7 +5131,6 @@
       "version": "1.1.1",
       "resolved": "http://registry.npm.taobao.org/string_decoder/download/string_decoder-1.1.1.tgz",
       "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       }
@@ -5429,8 +5740,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "http://registry.npm.taobao.org/util-deprecate/download/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",
@@ -5714,8 +6024,7 @@
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npm.taobao.org/xtend/download/xtend-4.0.2.tgz",
-      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q=",
-      "dev": true
+      "integrity": "sha1-u3J3n1+kZRhrH0OPZ0+jR/2121Q="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "onCommand:rest-client.save-response",
     "onCommand:rest-client.save-response-body",
     "onCommand:rest-client.copy-response-body",
+    "onCommand:rest-client.import-from-document",
     "onCommand:rest-client.switch-environment",
     "onCommand:rest-client.clear-aad-token-cache",
     "onCommand:rest-client.cancel-request",
@@ -101,6 +102,11 @@
       {
         "command": "rest-client.cancel-request",
         "title": "Cancel Request",
+        "category": "Rest Client"
+      },
+      {
+        "command": "rest-client.import-from-document",
+        "title": "Import Requests From Document",
         "category": "Rest Client"
       },
       {

--- a/package.json
+++ b/package.json
@@ -669,6 +669,7 @@
     "jsonc-parser": "^2.0.2",
     "jsonpath-plus": "^0.20.1",
     "mime-types": "^2.1.14",
+    "postman-collection": "^3.6.5",
     "pretty-data": "^0.40.0",
     "tough-cookie": "^3.0.1",
     "tough-cookie-file-store-bugfix": "Huachao/tough-cookie-file-store-bugfix",

--- a/src/controllers/importController.ts
+++ b/src/controllers/importController.ts
@@ -1,0 +1,28 @@
+import { CancellationToken, window, Uri } from 'vscode';
+import { trace } from '../utils/decorator';
+
+export class ImportController {
+
+    @trace('Import Requests From Document')
+    public async import(token: CancellationToken) {
+        const dialogOptions = { canSelectFiles: true, canSelectFolders: false, canSelectMany: false, title: 'Choose file that you wish to import' };
+        window.showQuickPick(['Postman'], { canPickMany: false }, token).then(option => {
+            window.showOpenDialog(dialogOptions).then(files => this.importFile(files?.pop(), option));
+        });
+    }
+
+    private async importFile(file: Uri | undefined, option: string | undefined) {
+        if (file === undefined) {
+            window.showErrorMessage("File was not found.");
+        }
+        if (option === undefined) {
+            window.showErrorMessage("Options was not found.");
+        }
+        
+        /* 
+        1. resolve importer based on option.
+        2. map content from imported file to text in specific format.
+        3. open new document with text (maybe we can use httpResponseTextDocumentView.ts)
+        */
+    }
+}

--- a/src/controllers/importController.ts
+++ b/src/controllers/importController.ts
@@ -1,5 +1,6 @@
-import { CancellationToken, window, Uri } from 'vscode';
+import { window, workspace } from 'vscode';
 import { trace } from '../utils/decorator';
+import { PostmanImporter } from './../utils/importers/PostmanCollectionImporter';
 
 export class ImportController {
 
@@ -18,7 +19,17 @@ export class ImportController {
         if (option === undefined) {
             window.showErrorMessage("Options was not found.");
         }
-        
+
+        if (option === 'Postman') {
+            const fileContent = await workspace.fs.readFile(<Uri>file);
+            const jsonObj = JSON.parse(fileContent.toString());
+
+            const importer = new PostmanImporter();
+            const parsedContent = importer.import(jsonObj);
+            const document = await workspace.openTextDocument({ language: 'http', content: parsedContent });
+            await window.showTextDocument(document, { preview: false });
+        }
+
         /* 
         1. resolve importer based on option.
         2. map content from imported file to text in specific format.

--- a/src/controllers/importController.ts
+++ b/src/controllers/importController.ts
@@ -1,6 +1,7 @@
-import { window, workspace } from 'vscode';
+import { Collection } from 'postman-collection';
+import { CancellationToken, Uri, window, workspace } from 'vscode';
 import { trace } from '../utils/decorator';
-import { PostmanImporter } from './../utils/importers/PostmanCollectionImporter';
+import { PostmanCollection, PostmanImporter } from './../utils/importers/PostmanCollectionImporter';
 
 export class ImportController {
 
@@ -25,12 +26,13 @@ export class ImportController {
             const jsonObj = JSON.parse(fileContent.toString());
 
             const importer = new PostmanImporter();
-            const parsedContent = importer.import(jsonObj);
+            const collection = new Collection(jsonObj);
+            const parsedContent = importer.import(<PostmanCollection>collection);
             const document = await workspace.openTextDocument({ language: 'http', content: parsedContent });
             await window.showTextDocument(document, { preview: false });
         }
 
-        /* 
+        /*
         1. resolve importer based on option.
         2. map content from imported file to text in specific format.
         3. open new document with text (maybe we can use httpResponseTextDocumentView.ts)

--- a/src/controllers/importController.ts
+++ b/src/controllers/importController.ts
@@ -31,11 +31,5 @@ export class ImportController {
             const document = await workspace.openTextDocument({ language: 'http', content: parsedContent });
             await window.showTextDocument(document, { preview: false });
         }
-
-        /*
-        1. resolve importer based on option.
-        2. map content from imported file to text in specific format.
-        3. open new document with text (maybe we can use httpResponseTextDocumentView.ts)
-        */
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,8 @@
+import { ImportController } from './controllers/importController';
 'use strict';
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
-import { commands, ExtensionContext, languages, Range, TextDocument, Uri, window, workspace } from 'vscode';
+import { commands, ExtensionContext, languages, Range, TextDocument, Uri, window, workspace, CancellationToken } from 'vscode';
 import { CodeSnippetController } from './controllers/codeSnippetController';
 import { EnvironmentController } from './controllers/environmentController';
 import { HistoryController } from './controllers/historyController';
@@ -29,6 +30,7 @@ export async function activate(context: ExtensionContext) {
 
     const requestController = new RequestController(context);
     const historyController = new HistoryController();
+    const importController = new ImportController();
     const codeSnippetController = new CodeSnippetController(context);
     const environmentController = await EnvironmentController.create();
     context.subscriptions.push(requestController);
@@ -38,6 +40,7 @@ export async function activate(context: ExtensionContext) {
     context.subscriptions.push(commands.registerCommand('rest-client.request', ((document: TextDocument, range: Range) => requestController.run(range))));
     context.subscriptions.push(commands.registerCommand('rest-client.rerun-last-request', () => requestController.rerun()));
     context.subscriptions.push(commands.registerCommand('rest-client.cancel-request', () => requestController.cancel()));
+    context.subscriptions.push(commands.registerCommand('rest-client.import-from-document', (token: CancellationToken) => importController.import(token)));
     context.subscriptions.push(commands.registerCommand('rest-client.history', () => historyController.save()));
     context.subscriptions.push(commands.registerCommand('rest-client.clear-history', () => historyController.clear()));
     context.subscriptions.push(commands.registerCommand('rest-client.generate-codesnippet', () => codeSnippetController.run()));

--- a/src/utils/importers/ImporterUtilities.ts
+++ b/src/utils/importers/ImporterUtilities.ts
@@ -1,0 +1,6 @@
+export class ImporterUtilities {
+
+    public static parseStringAsComment(str: string, symbol: string = '#', whitespaceAfterSymbol: boolean = true): string {
+        return str.replace(/\n/g, '\n' + symbol) + (whitespaceAfterSymbol ? ' ' : '');
+    }
+}

--- a/src/utils/importers/ImporterUtilities.ts
+++ b/src/utils/importers/ImporterUtilities.ts
@@ -1,6 +1,6 @@
 export class ImporterUtilities {
 
-    public static parseStringAsComment(str: string, symbol: string = '#', whitespaceAfterSymbol: boolean = true): string {
+    public static parseMultiLineStringAsMultiLineComment(str: string, symbol: string = '#', whitespaceAfterSymbol: boolean = true): string {
         return str.replace(/\n/g, '\n' + symbol) + (whitespaceAfterSymbol ? ' ' : '');
     }
 }

--- a/src/utils/importers/PostmanCollectionImporter.ts
+++ b/src/utils/importers/PostmanCollectionImporter.ts
@@ -38,9 +38,6 @@ export class PostmanImporter {
 
     writeRequest(requestId: string, req: Request): string {
         let sb = '';
-        if (requestId === 'get3DRevisions') {
-            debugger;
-        }
 
         req.url.variables.each((variable) => {
             sb += `@${requestId + variable.key} = ` + variable.value + EOL;

--- a/src/utils/importers/PostmanCollectionImporter.ts
+++ b/src/utils/importers/PostmanCollectionImporter.ts
@@ -17,7 +17,7 @@ export class PostmanImporter {
         return sb;
     }
     prepareGroupHeader(name: string, content: string): string {
-        return '#\t' + name + EOL + '#\t' + ImporterUtilities.parseStringAsComment(content);
+        return '#\t' + name + EOL + '#\t' + ImporterUtilities.parseMultiLineStringAsMultiLineComment(content);
     }
     writeAllRequestsInGroup(items: PropertyList): string {
         let sb = '';
@@ -53,7 +53,7 @@ export class PostmanImporter {
     prepareDocumentHeader(name: string, description: string): string {
         return `# ${name}` + EOL +
             `#` + EOL +
-            `# ${ImporterUtilities.parseStringAsComment(description)}` + EOL;
+            `# ${ImporterUtilities.parseMultiLineStringAsMultiLineComment(description)}` + EOL;
     }
 
     defineDocumentVariables(variables: VariableList): string {
@@ -61,7 +61,7 @@ export class PostmanImporter {
 
         variables.each(variable => {
             if (variable.description.content.length > 0) {
-                sb += `// ${ImporterUtilities.parseStringAsComment(variable.description.content)}` + EOL;
+                sb += `// ${ImporterUtilities.parseMultiLineStringAsMultiLineComment(variable.description.content)}` + EOL;
             }
 
             sb += `@${variable.key} = ${variable.value}` + EOL;

--- a/src/utils/importers/PostmanCollectionImporter.ts
+++ b/src/utils/importers/PostmanCollectionImporter.ts
@@ -1,19 +1,15 @@
 import { EOL } from 'os';
-import { Collection, PostmanRequest, VariableList, PostmanPropertyList } from 'postman-collection';
+import { Collection, PropertyList, Request, VariableList } from 'postman-collection';
 import { ImporterUtilities } from './ImporterUtilities';
 
-export interface PostmanItemGroup {
-
-}
 
 export class PostmanImporter {
-    import(collection: any): string {
+    import(collection: PostmanCollection): string {
         let sb = '';
-        const importedCollection = new Collection(collection);
 
-        sb += this.prepareDocumentHeader(importedCollection.name, importedCollection.description.content);
-        sb += this.defineDocumentVariables(importedCollection.variables);
-        importedCollection.items.each(entry => {
+        sb += this.prepareDocumentHeader(collection.name, collection.description.content);
+        sb += this.defineDocumentVariables(collection.variables);
+        collection.items.each(entry => {
             sb += this.prepareGroupHeader(entry.name, entry.description.content);
             sb += this.writeAllRequestsInGroup(entry.items);
         }, this);
@@ -23,9 +19,9 @@ export class PostmanImporter {
     prepareGroupHeader(name: string, content: string): string {
         return '#\t' + name + EOL + '#\t' + ImporterUtilities.parseStringAsComment(content);
     }
-    writeAllRequestsInGroup(items: PostmanPropertyList): string {
+    writeAllRequestsInGroup(items: PropertyList): string {
         let sb = '';
-        items.each(element => {
+        items.each((element: { id: string; name: string; request: any; }) => {
             sb += this.writeRequestHeader(element.id, element.name);
             const req = element.request;
             sb += this.writeRequest(req);
@@ -39,10 +35,10 @@ export class PostmanImporter {
             `# ${name}` + EOL;
     }
 
-    writeRequest(req: PostmanRequest): string {
+    writeRequest(req: Request): string {
         let sb = `${req.method} ${req.url.getPath()}${EOL}`;
 
-        req.headers.each(header => {
+        req.headers.each((header: { key: any; value: any; }) => {
             sb += `${header.key}: ${header.value}` + EOL;
         }, this);
 
@@ -72,4 +68,8 @@ export class PostmanImporter {
         }, this);
         return sb;
     }
+}
+
+export class PostmanCollection extends Collection {
+    description: { content: string };
 }

--- a/src/utils/importers/PostmanCollectionImporter.ts
+++ b/src/utils/importers/PostmanCollectionImporter.ts
@@ -1,0 +1,75 @@
+import { EOL } from 'os';
+import { Collection, PostmanRequest, VariableList, PostmanPropertyList } from 'postman-collection';
+import { ImporterUtilities } from './ImporterUtilities';
+
+export interface PostmanItemGroup {
+
+}
+
+export class PostmanImporter {
+    import(collection: any): string {
+        let sb = '';
+        const importedCollection = new Collection(collection);
+
+        sb += this.prepareDocumentHeader(importedCollection.name, importedCollection.description.content);
+        sb += this.defineDocumentVariables(importedCollection.variables);
+        importedCollection.items.each(entry => {
+            sb += this.prepareGroupHeader(entry.name, entry.description.content);
+            sb += this.writeAllRequestsInGroup(entry.items);
+        }, this);
+
+        return sb;
+    }
+    prepareGroupHeader(name: string, content: string): string {
+        return '#\t' + name + EOL + '#\t' + ImporterUtilities.parseStringAsComment(content);
+    }
+    writeAllRequestsInGroup(items: PostmanPropertyList): string {
+        let sb = '';
+        items.each(element => {
+            sb += this.writeRequestHeader(element.id, element.name);
+            const req = element.request;
+            sb += this.writeRequest(req);
+        }, this);
+        return sb;
+    }
+
+    writeRequestHeader(id: string, name: string): string {
+        return EOL +
+            `# @name ${id}` + EOL +
+            `# ${name}` + EOL;
+    }
+
+    writeRequest(req: PostmanRequest): string {
+        let sb = `${req.method} ${req.url.getPath()}${EOL}`;
+
+        req.headers.each(header => {
+            sb += `${header.key}: ${header.value}` + EOL;
+        }, this);
+
+        if (req.body) {
+            sb += req.body.toString() + EOL;
+        }
+        sb += EOL + '###' + EOL;
+
+        return sb;
+    }
+
+    prepareDocumentHeader(name: string, description: string): string {
+        return `# ${name}` + EOL +
+            `#` + EOL +
+            `# ${ImporterUtilities.parseStringAsComment(description)}` + EOL;
+    }
+
+    defineDocumentVariables(variables: VariableList): string {
+        let sb = '';
+
+        variables.each(variable => {
+            if (variable.description.content.length > 0) {
+                sb += `// ${ImporterUtilities.parseStringAsComment(variable.description.content)}` + EOL;
+            }
+
+            sb += `@${variable.key} = ${variable.value}` + EOL;
+        }, this);
+        return sb;
+    }
+}


### PR DESCRIPTION
As in the topic, I've created implementation to automatically import postman collection to the vscode by creating virtual document with HTTP requests within it exactly in a postman format.
Currently unsupported:
- authorization-specific settings from postman collection.

I wanted to share it with you early so you can give me your feedback. 
I want to restructure this code soon. I want to create a resolver class that will be the factory for the option-specific importers.

Next steps:
- https://github.com/postmanlabs/openapi-to-postman to convert OpenAPI documents to the postman collection and using the existing importer, that I've already created, convert to rest-client document.
- https://github.com/postmanlabs/swagger2-postman2 - the same but with swagger...
etc.

Anyway - if we make good work there then we can receive really nice way to import many things using the good stuff that postmanlabs team delivers. The license is an apache 2.0 so I don't know if that is a problem or not..

Demo:

![1](https://user-images.githubusercontent.com/9272027/91488032-004a1f80-e8af-11ea-92b8-77339d5c897e.gif)
