### PR TITLE
Updating document selector to support virtual file systems

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -51,8 +51,7 @@ export async function activate(context: ExtensionContext) {
     }));
 
     const documentSelector = [
-        { language: 'http', scheme: 'file' },
-        { language: 'http', scheme: 'untitled' },
+        { language: 'http', scheme: '*' }
     ];
 
     context.subscriptions.push(languages.registerCompletionItemProvider(documentSelector, new HttpCompletionItemProvider()));


### PR DESCRIPTION
This PR simply updates the document selector that is used to register the HTTP language services. By using a `*` scheme, this enables support for HTTP files stored in arbitrary file systems. For example, the [GistPad](https://aka.ms/gistpad) extension allows editing files that are stored in GitHub Gists and repos, and with this change, you can edit/send requests from them.