### PR TITLE
Added FileHeader support with @@ syntax

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -61,7 +61,7 @@ export const AzureClouds: { [key: string]: { aad: string, arm: string, armAudien
 
 export const CommentIdentifiersRegex: RegExp = /^\s*(#|\/{2})/;
 
-export const FileVariableDefinitionRegex: RegExp = /^\s*@([^\s=]+)\s*=\s*(.*?)\s*$/;
+export const FileVariableDefinitionRegex: RegExp = /^\s*@([^\s=@]+)\s*=\s*(.*?)\s*$/;
 
 export const RequestVariableDefinitionWithNameRegexFactory = (name: string, flags?: string): RegExp =>
     new RegExp(`^\\s*(?:#{1,}|\\/{2,})\\s+@name\\s+(${name})\\s*$`, flags);
@@ -71,3 +71,5 @@ export const RequestVariableDefinitionRegex: RegExp = RequestVariableDefinitionW
 export const NoteCommentRegex = /^\s*(?:#{1,}|\/{2,})\s*@note\s*$/m;
 
 export const LineSplitterRegex: RegExp = /\r?\n/g;
+
+export const FileHeaderDefinitionRegex: RegExp = /^\s*@@(.*?)\s*$/;

--- a/src/utils/selector.ts
+++ b/src/utils/selector.ts
@@ -8,6 +8,7 @@ export interface RequestRangeOptions {
     ignoreEmptyLine?: boolean;
     ignoreFileVariableDefinitionLine?: boolean;
     ignoreResponseRange?: boolean;
+    ignoreFileHeaderVariableDefinitionLine?: boolean;
 }
 
 export interface SelectedRequest {
@@ -67,6 +68,7 @@ export class Selector {
                 ignoreEmptyLine: true,
                 ignoreFileVariableDefinitionLine: true,
                 ignoreResponseRange: true,
+                ignoreFileHeaderVariableDefinitionLine: true,
             ...options};
         const requestRanges: [number, number][] = [];
         const delimitedLines = this.getDelimiterRows(lines);
@@ -84,7 +86,8 @@ export class Selector {
 
                 if (options.ignoreCommentLine && this.isCommentLine(startLine)
                     || options.ignoreEmptyLine && this.isEmptyLine(startLine)
-                    || options.ignoreFileVariableDefinitionLine && this.isFileVariableDefinitionLine(startLine)) {
+                    || options.ignoreFileVariableDefinitionLine && this.isFileVariableDefinitionLine(startLine)
+                    || options.ignoreFileHeaderVariableDefinitionLine && this.isFileHeaderDefinitionLine(startLine)) {
                     start++;
                     continue;
                 }
@@ -134,9 +137,33 @@ export class Selector {
         return Constants.NoteCommentRegex.test(text);
     }
 
+    public static isFileHeaderDefinitionLine(line: string): boolean {
+        return Constants.FileHeaderDefinitionRegex.test(line);
+    }
+
+    public static getFileHeaderLines(lines: string[]):  string[] | undefined {
+        let result: string[] = new Array<string>();
+        lines.forEach(line => {
+            let m =  Constants.FileHeaderDefinitionRegex.exec(line);
+            if(m)
+            {
+                result.push(m[1]);
+            }
+        });
+        return result;
+    }
+
     private static getDelimitedText(fullText: string, currentLine: number): string | null {
         const lines: string[] = fullText.split(Constants.LineSplitterRegex);
         const delimiterLineNumbers: number[] = this.getDelimiterRows(lines);
+
+        let fileHeaders ;
+        if(delimiterLineNumbers.length == 0){
+            fileHeaders =  Selector.getFileHeaderLines(lines);
+        } else {
+            fileHeaders = Selector.getFileHeaderLines(lines.slice(0, currentLine))
+        }
+
         if (delimiterLineNumbers.length === 0) {
             return fullText;
         }
@@ -146,20 +173,31 @@ export class Selector {
             return null;
         }
 
+        
+        let requestLines: Array<string> | undefined;
+
         if (currentLine < delimiterLineNumbers[0]) {
-            return lines.slice(0, delimiterLineNumbers[0]).join(EOL);
+            requestLines = lines.slice(0, delimiterLineNumbers[0]);
         }
 
         if (currentLine > delimiterLineNumbers[delimiterLineNumbers.length - 1]) {
-            return lines.slice(delimiterLineNumbers[delimiterLineNumbers.length - 1] + 1).join(EOL);
+            requestLines = lines.slice(delimiterLineNumbers[delimiterLineNumbers.length - 1] + 1);
         }
 
         for (let index = 0; index < delimiterLineNumbers.length - 1; index++) {
             const start = delimiterLineNumbers[index];
             const end = delimiterLineNumbers[index + 1];
             if (start < currentLine && currentLine < end) {
-                return lines.slice(start + 1, end).join(EOL);
+                requestLines = lines.slice(start + 1, end);
             }
+        }
+
+        if(requestLines) {
+            if(fileHeaders) {
+                requestLines.splice(1,0, ...fileHeaders);
+            }
+
+            return requestLines.join(EOL);
         }
 
         return null;


### PR DESCRIPTION
I added support for specifying header variables with **@@** prefix (#737 ).

The file headers are processed based on the position of http request so that any file header above the request is automatically added to the list of request headers.

Also variable expansion in file headers are supported.

Sample usage:

```
@url  = https://jsonplaceholder.typicode.com/todos/1
@@Content-Type: application/json

### Request 1 with Content-Type header
GET {{url}}

### new header
@token = myAuthToken
@@Authorization: Bearer {{token}}


### Request 2 with Content-Type, Auhtorization and Accept-Encoding headers
GET {{url}}
Accept-Encoding: gzip
````