### PR TITLE
Fix isJSON for AWS content type

### DIFF
--- a/src/utils/mimeUtility.ts
+++ b/src/utils/mimeUtility.ts
@@ -65,7 +65,7 @@ export class MimeUtility {
         }
 
         const { subtype, essence } = this.parse(contentTypeString);
-        return essence === 'application/json' || subtype.endsWith('+json');
+        return essence === 'application/json' || subtype.endsWith('+json') || subtype.startsWith('x-amz-json');
     }
 
     public static isXml(contentTypeString: string | undefined): boolean {


### PR DESCRIPTION
I create this PR to deals with the following issue.

When working with some AWS API, you have to use the "application/x-amz-json-1.1" content type. 
The issue is this content type is not recognized as JSON and so, you can not bind the result to variable. 
Instead you get the following error : "Only JSON and XML response/request body is supported to query the result"

You can reproduce the issue with this snippet:
```
# @name login
POST https://cognito-idp.eu-west-1.amazonaws.com
Content-Type: application/x-amz-json-1.1
X-Amz-Target: AWSCognitoIdentityProviderService.InitiateAuth


{
   "AuthParameters" : {
      "USERNAME" : "<user>",
      "PASSWORD" : "<pwd>"
   },
   "AuthFlow" : "USER_PASSWORD_AUTH",
   "ClientId" : "123456789"
}
@id_token = {{login.response.body.AuthenticationResult.IdToken}}
```
