### PR TITLE
Update azure ad token caching

### DIFF
--- a/src/utils/aadV2TokenProvider.ts
+++ b/src/utils/aadV2TokenProvider.ts
@@ -171,8 +171,8 @@ class AuthParameters {
         return undefined;
     }
 
-    getCacheKey() : string {
-        return this.tenantId + "|" + this.clientId + "|" + this.appOnly as string;
+    getCacheKey(): string {
+        return this.tenantId + "|" + this.clientId + "|" + this.appOnly + "|" + this.scopes.join(',') as string;
     }
 
     static async parseName(name: string): Promise<AuthParameters> {


### PR DESCRIPTION
1. include scopes in cache key
       different network request may need token with different scopes , so include scopes in cache key
2. include original requested scopes also in cache scope
       Sometime token is missing requested scopes.
       When next request is sent with same scope application is asking for re authentication.
       Including original scopes in saved scopes fixes that