### PR TITLE
Support cUrl SSL client certificate options

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ We add the capability to directly run [curl request](https://curl.haxx.se/) in R
 * -b, --cookie(no cookie jar file support)
 * -u, --user(Basic auth support only)
 * -d, --data, --data-ascii,--data-binary, --data-raw
+* -E, --cert
+* --key
++ --pass
+* --cacert
 
 ## Copy Request As cURL
 Sometimes you may want to get the curl format of an http request quickly and save it to clipboard, just pressing `F1` and then selecting/typing `Rest Client: Copy Request As cURL` or simply right-click in the editor, and select `Copy Request As cURL`.

--- a/src/models/base.ts
+++ b/src/models/base.ts
@@ -1,5 +1,14 @@
 import * as http from 'http';
 
+// supported subset of the TLS options => https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
+export type HttpsOptions = {
+    cert?: string;
+    key?: string;
+    ca?: string;
+    pfx?: string;
+    passphrase?: string;
+};
+
 export type ResponseHeaders = http.IncomingHttpHeaders;
 
 export type ResponseHeaderValue = { [K in keyof ResponseHeaders]: ResponseHeaders[K] }[keyof ResponseHeaders];

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -1,18 +1,13 @@
 import { CharacterPair, Event, EventEmitter, languages, ViewColumn, window, workspace } from 'vscode';
 import configuration from '../../language-configuration.json';
 import { getCurrentTextDocument } from '../utils/workspaceUtility';
-import { RequestHeaders } from './base';
+import { HttpsOptions, RequestHeaders } from './base';
 import { FormParamEncodingStrategy, fromString as ParseFormParamEncodingStr } from './formParamEncodingStrategy';
 import { fromString as ParseLogLevelStr, LogLevel } from './logLevel';
 import { fromString as ParsePreviewOptionStr, PreviewOption } from './previewOption';
 
 export type HostCertificates = {
-    [key: string]: {
-        cert?: string;
-        key?: string;
-        pfx?: string;
-        passphrase?: string;
-    }
+    [key: string]: HttpsOptions
 };
 
 interface IRestClientSettings {

--- a/src/models/httpRequest.ts
+++ b/src/models/httpRequest.ts
@@ -1,6 +1,6 @@
 import { Stream } from 'stream';
 import { getContentType } from '../utils/misc';
-import { RequestHeaders } from './base';
+import { HttpsOptions, RequestHeaders } from './base';
 
 export class HttpRequest {
     public isCancelled: boolean;
@@ -10,7 +10,8 @@ export class HttpRequest {
         public headers: RequestHeaders,
         public body?: string | Stream,
         public rawBody?: string,
-        public name?: string) {
+        public name?: string,
+        public https?: HttpsOptions) {
             this.method = method.toLocaleUpperCase();
             this.isCancelled = false;
     }
@@ -30,6 +31,7 @@ export class HistoricalHttpRequest {
         public url: string,
         public headers: RequestHeaders,
         public body: string | undefined,
+        public https: HttpsOptions | undefined,
         public startTime: number) {
     }
 
@@ -39,6 +41,7 @@ export class HistoricalHttpRequest {
             httpRequest.url,
             httpRequest.headers,
             httpRequest.rawBody,
+            httpRequest.https,
             startTime
         );
     }


### PR DESCRIPTION
extend cUrl parser to parse:
* -E or --cert
* --key
* --pass
* --cacert

extend httpRequest to have https options.

prefere https options of the request
over the https options from the settings