### PR TITLE
Support multiple values for JSON PATH

### DIFF
--- a/src/utils/requestVariableCacheValueProcessor.ts
+++ b/src/utils/requestVariableCacheValueProcessor.ts
@@ -86,7 +86,7 @@ export class RequestVariableCacheValueProcessor {
     private static resolveJsonHttpBody(body: any, path: string): ResolveResult {
         try {
             const result = JSONPath({ path, json: body });
-            const value = typeof result[0] === 'string' ? result[0] : JSON.stringify(result[0]);
+            const value = result.length > 1 ? JSON.stringify(result) : typeof result[0] === 'string' ? result[0] : JSON.stringify(result[0]);
             if (!value) {
                 return { state: ResolveState.Warning, message: ResolveWarningMessage.IncorrectJSONPath };
             } else {


### PR DESCRIPTION
Related https://github.com/Huachao/vscode-restclient/issues/197

I want to get user ids from this response:

```json
{
  "payload": {
    "results": [
      {
        "user": {
          "id": "aaa",
          "name": "alice",
          "iconUrl": "https://foo/bar"
        },
        "isFollowed": false,
        "isFollowing": true
      },
      {
        "user": {
          "id": "bbb",
          "name": "alice",
          "iconUrl": "https://foo/bar"
        },
        "isFollowed": false,
        "isFollowing": true
      },
      {
        "user": {
          "id": "ccc",
          "name": "alice",
          "iconUrl": "https://foo/bar"
        },
        "isFollowed": false,
        "isFollowing": true
      }
    ]
  }
}
```

with

```
@userIds = {{search.response.body.$..user.id}}
```

expected result is `["aaa","bbb","ccc"]` (string). So I can send `userIds` with next request

```
POST some/api

{
  "userIds": {{userIds}}
}
```

Works as usual if JSON path is matching to only one element.