### PR TITLE
Solution for https://github.com/Huachao/vscode-restclient/issues/858

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -669,6 +669,11 @@
       "integrity": "sha1-ZfCvOC9Xi83HQr2cKB6cstd2gyg=",
       "dev": true
     },
+    "bignumber.js": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+      "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npm.taobao.org/binary-extensions/download/binary-extensions-1.13.1.tgz",
@@ -2837,6 +2842,14 @@
       "resolved": "http://registry.npm.taobao.org/jsbn/download/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
       "optional": true
+    },
+    "json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "requires": {
+        "bignumber.js": "^9.0.0"
+      }
     },
     "json-buffer": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -659,6 +659,7 @@
     "https-proxy-agent": "^2.2.3",
     "httpsnippet": "^1.22.0",
     "iconv-lite": "^0.4.15",
+    "json-bigint": "^1.0.0",
     "jsonc-parser": "^2.0.2",
     "jsonpath-plus": "^0.20.1",
     "mime-types": "^2.1.14",

--- a/src/utils/requestVariableCacheValueProcessor.ts
+++ b/src/utils/requestVariableCacheValueProcessor.ts
@@ -3,6 +3,7 @@ import { HttpResponse } from '../models/httpResponse';
 import { ResolveErrorMessage, ResolveResult, ResolveState, ResolveWarningMessage } from "../models/httpVariableResolveResult";
 import { MimeUtility } from './mimeUtility';
 import { getContentType, getHeader, isJSONString } from './misc';
+import JSONbig from 'json-bigint';
 
 const xpath = require('xpath');
 const { DOMParser } = require('xmldom');
@@ -59,7 +60,7 @@ export class RequestVariableCacheValueProcessor {
 
             const contentTypeHeader = getContentType(headers);
             if (MimeUtility.isJSON(contentTypeHeader) || (MimeUtility.isJavaScript(contentTypeHeader) && isJSONString(body as string))) {
-                const parsedBody = JSON.parse(body as string);
+                const parsedBody = JSONbig.parse(body as string);
 
                 return this.resolveJsonHttpBody(parsedBody, nameOrPath);
             } else if (MimeUtility.isXml(contentTypeHeader)) {
@@ -86,7 +87,7 @@ export class RequestVariableCacheValueProcessor {
     private static resolveJsonHttpBody(body: any, path: string): ResolveResult {
         try {
             const result = JSONPath({ path, json: body });
-            const value = typeof result[0] === 'string' ? result[0] : JSON.stringify(result[0]);
+            const value = typeof result[0] === 'string' ? result[0] : JSONbig.stringify(result[0]);
             if (!value) {
                 return { state: ResolveState.Warning, message: ResolveWarningMessage.IncorrectJSONPath };
             } else {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,10 @@ const config = {
         vscode: "commonjs vscode" // the vscode-module is created on-the-fly and must be excluded. Add other modules that cannot be webpack'ed, 📖 -> https://webpack.js.org/configuration/externals/
     },
     resolve: { // support reading TypeScript and JavaScript files, 📖 -> https://github.com/TypeStrong/ts-loader
-        extensions: ['.ts', '.js']
+        extensions: ['.ts', '.js'],
+        alias: {
+            "bignumber.js$": "bignumber.js/bignumber.js"
+        }
     },
     module: {
         rules: [{


### PR DESCRIPTION
Replaced the default variable processing by replacing `JSON`with `JSONbig` for both parse and stringify.

The changes to `webpack.config.js` are to avoid an issue with the usage of `bignumber.js` by the `json-bigint` package under `webpack`.
