### PR TITLE
Allow comments between variable declarations

### DIFF
--- a/src/providers/fileVariableReferencesCodeLensProvider.ts
+++ b/src/providers/fileVariableReferencesCodeLensProvider.ts
@@ -19,7 +19,7 @@ export class FileVariableReferencesCodeLensProvider implements CodeLensProvider 
         for (let [blockStart, blockEnd] of requestRanges) {
             for (; blockStart <= blockEnd; blockStart++) {
                 const line = lines[blockStart];
-                if(Selector.isCommentLine(line)) {
+                if (Selector.isCommentLine(line)) {
                     continue;
                 } else if (!Selector.isFileVariableDefinitionLine(line)) {
                     break;

--- a/src/providers/fileVariableReferencesCodeLensProvider.ts
+++ b/src/providers/fileVariableReferencesCodeLensProvider.ts
@@ -17,9 +17,11 @@ export class FileVariableReferencesCodeLensProvider implements CodeLensProvider 
         const requestRanges: [number, number][] = Selector.getRequestRanges(lines, { ignoreFileVariableDefinitionLine: false });
 
         for (let [blockStart, blockEnd] of requestRanges) {
-            while (blockStart <= blockEnd) {
+            for (; blockStart <= blockEnd; blockStart++) {
                 const line = lines[blockStart];
-                if (!Selector.isFileVariableDefinitionLine(line)) {
+                if(Selector.isCommentLine(line)) {
+                    continue;
+                } else if (!Selector.isFileVariableDefinitionLine(line)) {
                     break;
                 }
 
@@ -35,7 +37,6 @@ export class FileVariableReferencesCodeLensProvider implements CodeLensProvider 
                     };
                     blocks.push(new CodeLens(range, cmd));
                 }
-                blockStart++;
             }
         }
 


### PR DESCRIPTION
These changes aim to fix #883 by skipping comment lines when analysing variable blocks to show reference counts.

### Before

```http
# Foo
@foo = abc
# Bar
@bar = xyz
@quz=ijk

GET https://abc.xyz?foo={{foo}}&bar={{bar}}
```

![image](https://user-images.githubusercontent.com/8406735/126777834-94011b38-1272-488a-a63b-9ed38b191e20.png)

### After

![Immagine 2021-07-24 154707](https://user-images.githubusercontent.com/8406735/126870557-b8f7ac76-190b-48f5-b2fa-bd202e0e9b74.png)

### Tests

I have no experience whatsoever with this codebase so I'm not sure wether changing this file is enough or other files need to be changed, but in my tests it worked as expected:

```http
# Foo
@foo = abc
# Bar
@bar = xyz
@quz=ijk

GET http://urlecho.appspot.com/echo?body={{foo}}+X+{{bar}}+X+{{bar}}
```

![image](https://user-images.githubusercontent.com/8406735/126870910-57ad5faa-4083-4315-b519-9a048176bd7c.png)

![image](https://user-images.githubusercontent.com/8406735/126870941-717b4563-e6be-4470-a6a9-6084ea638bb3.png)


