### PR TITLE
SaveBody now uses filename from content-disposition

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ exchange | Preview the whole HTTP exchange(request and response)
 * `rest-client.logLevel`: The verbosity of logging in the REST output panel. (Default is __error__)
 * `rest-client.enableSendRequestCodeLens`: Enable/disable sending request CodeLens in request file. (Default is __true__)
 * `rest-client.enableCustomVariableReferencesCodeLens`: Enable/disable custom variable references CodeLens in request file. (Default is __true__)
+* `rest-client.useContentDispositionFilename`: Use `filename=` from `'content-disposition'` header (if available), to determine output file name, when saving response body. (Default is __true__)
 
 Rest Client extension respects the proxy settings made for Visual Studio Code (`http.proxy` and `http.proxyStrictSSL`). Only HTTP and HTTPS proxies are supported.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1229,6 +1229,14 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
+    "content-disposition": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
+      "integrity": "sha512-ExO0774ikEObIAEV9kDo50o+79VCUdEB6n6lzKgGwupcVeRlhrj3qGAfwq8G6uBJjkqLrhT0qEYFcWng8z1z0g==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "copy-concurrently": {
       "version": "1.0.5",
       "resolved": "http://registry.npm.taobao.org/copy-concurrently/download/copy-concurrently-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -609,6 +609,12 @@
           "default": true,
           "scope": "resource",
           "description": "Enable/disable custom variable references CodeLens in request file"
+        },
+        "rest-client.useContentDispositionFilename": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource",
+          "description": "Enable/disable using filename from 'content-disposition' header, when saving response body"
         }
       }
     },
@@ -648,6 +654,7 @@
     "aws4": "^1.9.1",
     "code-highlight-linenums": "^0.2.1",
     "combined-stream": "^1.0.5",
+    "content-disposition": "^0.5.3",
     "dayjs": "^1.8.20",
     "dotenv": "^8.2.0",
     "encodeurl": "^1.0.1",

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -46,6 +46,7 @@ interface IRestClientSettings {
     logLevel: LogLevel;
     enableSendRequestCodeLens: boolean;
     enableCustomVariableReferencesCodeLens: boolean;
+    useContentDispositionFilename: boolean;
 }
 
 export class RestClientSettings implements IRestClientSettings {
@@ -79,6 +80,7 @@ export class RestClientSettings implements IRestClientSettings {
     public logLevel: LogLevel;
     public enableSendRequestCodeLens: boolean;
     public enableCustomVariableReferencesCodeLens: boolean;
+    public useContentDispositionFilename: boolean;
 
     private readonly brackets: CharacterPair[];
 
@@ -153,6 +155,7 @@ export class RestClientSettings implements IRestClientSettings {
         this.logLevel = ParseLogLevelStr(restClientSettings.get<string>('logLevel', 'error'));
         this.enableSendRequestCodeLens = restClientSettings.get<boolean>('enableSendRequestCodeLens', true);
         this.enableCustomVariableReferencesCodeLens = restClientSettings.get<boolean>('enableCustomVariableReferencesCodeLens', true);
+        this.useContentDispositionFilename = restClientSettings.get<boolean>('useContentDispositionFilename', true);
         languages.setLanguageConfiguration('http', { brackets: this.addRequestBodyLineIndentationAroundBrackets ? this.brackets : [] });
 
         const httpSettings = workspace.getConfiguration("http");

--- a/src/views/httpResponseWebview.ts
+++ b/src/views/httpResponseWebview.ts
@@ -2,18 +2,20 @@ import * as fs from 'fs-extra';
 import * as os from 'os';
 import { Clipboard, commands, env, ExtensionContext, Uri, ViewColumn, WebviewPanel, window, workspace } from 'vscode';
 import { RequestHeaders, ResponseHeaders } from '../models/base';
+import { RestClientSettings } from '../models/configurationSettings';
 import { HttpRequest } from '../models/httpRequest';
 import { HttpResponse } from '../models/httpResponse';
 import { PreviewOption } from '../models/previewOption';
 import { trace } from '../utils/decorator';
 import { disposeAll } from '../utils/dispose';
 import { MimeUtility } from '../utils/mimeUtility';
-import { base64, isJSONString } from '../utils/misc';
+import { base64, getHeader, isJSONString } from '../utils/misc';
 import { ResponseFormatUtility } from '../utils/responseFormatUtility';
 import { UserDataManager } from '../utils/userDataManager';
 import { BaseWebview } from './baseWebview';
 
 const hljs = require('highlight.js');
+const contentDisposition = require('content-disposition');
 
 const OPEN = 'Open';
 const COPYPATH = 'Copy Path';
@@ -144,15 +146,32 @@ export class HttpResponseWebview extends BaseWebview {
     @trace('Save Response Body')
     private async saveBody() {
         if (this.activeResponse) {
-            const extension = MimeUtility.getExtension(this.activeResponse.contentType, this.settings.mimeAndFileExtensionMapping);
-            const fileName = !extension ? `Response-${Date.now()}` : `Response-${Date.now()}.${extension}`;
+            const fileName = HttpResponseWebview.getResponseBodyOuptutFilename(this.activeResponse, this.settings);
             const defaultFilePath = UserDataManager.getResponseBodySaveFilePath(fileName);
+
             try {
                 await this.openSaveDialog(defaultFilePath, this.activeResponse.bodyBuffer);
             } catch {
                 window.showErrorMessage('Failed to save latest response body to disk');
             }
         }
+    }
+
+    private static getResponseBodyOuptutFilename(activeResponse: HttpResponse, settings: RestClientSettings) {
+        if (settings.useContentDispositionFilename) {
+            const cdHeader = getHeader(activeResponse.headers, 'content-disposition');
+            if (cdHeader) {
+                const disposition = contentDisposition.parse(cdHeader);
+                if ((disposition?.type === "attachment" || disposition?.type === "inline") && disposition?.parameters?.hasOwnProperty("filename")) {
+                    const serverProvidedFilename = disposition.parameters.filename;
+                    return serverProvidedFilename;
+                }
+            }
+        }
+
+        const extension = MimeUtility.getExtension(activeResponse.contentType, settings.mimeAndFileExtensionMapping);
+        const defaultFileName = !extension ? `Response-${Date.now()}` : `Response-${Date.now()}.${extension}`;
+        return defaultFileName;
     }
 
     private getTitle(response: HttpResponse): string {


### PR DESCRIPTION
Closes: #924 
(naive implementation, mostly as a proof of concept)

New behavior is toggle-able via useContentDispositionFilename setting (default true).
Only applies to "attachment" and "inline" disposition types (even though inline+filename response is not specifically following the syntax, it is often encountered in practice).

Note (on security): The extension does NOT sanitize the output filename and uses server-provided - equvalent of curl's --remote-header-name option).