### PR TITLE
Add Markdown support to run requests with code lenses

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support navigate to symbol definitions(request and file level custom variable) in open `http` file
     - CodeLens support to add an actionable link to send request
     - Fold/Unfold for request block
+* Support for Markdown fenced code blocks with either `http` or `rest`
 
 ## Usage
 In editor, type an HTTP request as simple as below:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "onCommand:rest-client.copy-request-as-curl",
     "onCommand:rest-client.fold-response",
     "onCommand:rest-client.unfold-response",
-    "onLanguage:http"
+    "onLanguage:http",
+    "onLanguage:markdown"
   ],
   "main": "./dist/extension",
   "contributes": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,9 +13,9 @@ import { FileVariableDefinitionProvider } from './providers/fileVariableDefiniti
 import { FileVariableReferenceProvider } from './providers/fileVariableReferenceProvider';
 import { FileVariableReferencesCodeLensProvider } from './providers/fileVariableReferencesCodeLensProvider';
 import { HttpCodeLensProvider } from './providers/httpCodeLensProvider';
-import { MarkdownCodeLensProvider } from './providers/markdownCodeLensProvider';
 import { HttpCompletionItemProvider } from './providers/httpCompletionItemProvider';
 import { HttpDocumentSymbolProvider } from './providers/httpDocumentSymbolProvider';
+import { MarkdownCodeLensProvider } from './providers/markdownCodeLensProvider';
 import { RequestVariableCompletionItemProvider } from "./providers/requestVariableCompletionItemProvider";
 import { RequestVariableDefinitionProvider } from './providers/requestVariableDefinitionProvider';
 import { RequestVariableHoverProvider } from './providers/requestVariableHoverProvider';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,6 +13,7 @@ import { FileVariableDefinitionProvider } from './providers/fileVariableDefiniti
 import { FileVariableReferenceProvider } from './providers/fileVariableReferenceProvider';
 import { FileVariableReferencesCodeLensProvider } from './providers/fileVariableReferencesCodeLensProvider';
 import { HttpCodeLensProvider } from './providers/httpCodeLensProvider';
+import { MarkdownCodeLensProvider } from './providers/markdownCodeLensProvider';
 import { HttpCompletionItemProvider } from './providers/httpCompletionItemProvider';
 import { HttpDocumentSymbolProvider } from './providers/httpDocumentSymbolProvider';
 import { RequestVariableCompletionItemProvider } from "./providers/requestVariableCompletionItemProvider";
@@ -54,6 +55,10 @@ export async function activate(context: ExtensionContext) {
         { language: 'http', scheme: '*' }
     ];
 
+    const mdDocumentSelector = [
+        { language: 'markdown', scheme: '*' }
+    ];
+
     context.subscriptions.push(languages.registerCompletionItemProvider(documentSelector, new HttpCompletionItemProvider()));
     context.subscriptions.push(languages.registerCompletionItemProvider(documentSelector, new RequestVariableCompletionItemProvider(), '.'));
     context.subscriptions.push(languages.registerHoverProvider(documentSelector, new EnvironmentOrFileVariableHoverProvider()));
@@ -66,6 +71,10 @@ export async function activate(context: ExtensionContext) {
         new ConfigurationDependentRegistration(
             () => languages.registerCodeLensProvider(documentSelector, new FileVariableReferencesCodeLensProvider()),
             s => s.enableCustomVariableReferencesCodeLens));
+    context.subscriptions.push(
+        new ConfigurationDependentRegistration(
+            () => languages.registerCodeLensProvider(mdDocumentSelector, new MarkdownCodeLensProvider()),
+            s => s.enableSendRequestCodeLens));
     context.subscriptions.push(languages.registerDocumentLinkProvider(documentSelector, new RequestBodyDocumentLinkProvider()));
     context.subscriptions.push(languages.registerDefinitionProvider(documentSelector, new FileVariableDefinitionProvider()));
     context.subscriptions.push(languages.registerDefinitionProvider(documentSelector, new RequestVariableDefinitionProvider()));

--- a/src/providers/markdownCodeLensProvider.ts
+++ b/src/providers/markdownCodeLensProvider.ts
@@ -1,0 +1,22 @@
+import { CancellationToken, CodeLens, CodeLensProvider, Command, Range, TextDocument } from 'vscode';
+import { Selector } from '../utils/selector';
+
+export class MarkdownCodeLensProvider implements CodeLensProvider {
+
+    public provideCodeLenses(document: TextDocument, _token: CancellationToken): Promise<CodeLens[]> {
+        const blocks: CodeLens[] = [];
+
+        for (const range of Selector.getMarkdownRestSnippets(document)) {
+            const snippetRange = new Range(range.start.line + 1, 0, range.end.line, 0);
+            const cmd: Command = {
+                arguments: [document, snippetRange],
+                title: 'Send Request',
+                command: 'rest-client.request',
+            };
+            blocks.push(new CodeLens(range, cmd));
+        }
+
+        return Promise.resolve(blocks);
+    }
+
+}


### PR DESCRIPTION
This PR allows you to run your requests directly from a `markdown` file. It displays a code lens `Send Request` when it detects a new code block using `http` language.

![rest-client-md-support](https://user-images.githubusercontent.com/4592980/143894125-37a4bbf0-a888-4b64-b3dc-ac38599b7c9b.gif)

This has been previously discussed in https://github.com/Huachao/vscode-restclient/issues/53#issuecomment-265009922. There is no new shortcuts, only displaying code lenses. Moreover, if you select `Send Request` from the command palette, it will run the code block where the active line is in. I hope this does not cause any conflict.

The goal behind this PR is to make Markdown to be live documentation, in the spirit of org-mode. Your extension is the perfect tool to implement this feature. Thanks for the good work!
 
Looking forward to hear your comments.