### PR TITLE
Support for AsciiDoc fenced code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
     - Support navigate to symbol definitions(request and file level custom variable) in open `http` file
     - CodeLens support to add an actionable link to send request
     - Fold/Unfold for request block
+* Support for AsciiDoc fenced code blocks
 
 ## Usage
 In editor, type an HTTP request as simple as below:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rest-client",
-  "version": "0.24.5",
+  "version": "0.24.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "onCommand:rest-client.copy-request-as-curl",
     "onCommand:rest-client.fold-response",
     "onCommand:rest-client.unfold-response",
-    "onLanguage:http"
+    "onLanguage:http",
+    "onLanguage:asciidoc"
   ],
   "main": "./dist/extension",
   "contributes": {

--- a/src/providers/asciidocCodeLensProvider.ts
+++ b/src/providers/asciidocCodeLensProvider.ts
@@ -1,0 +1,22 @@
+import { CancellationToken, CodeLens, CodeLensProvider, Command, Range, TextDocument } from 'vscode';
+import { Selector } from '../utils/selector';
+
+ export class AsciidocCodeLensProvider implements CodeLensProvider {
+
+     public provideCodeLenses(document: TextDocument, _token: CancellationToken): Promise<CodeLens[]> {
+         const blocks: CodeLens[] = [];
+
+         for (const range of Selector.getAsciidocRestSnippets(document)) {
+             const snippetRange = new Range(range.start.line + 2, 0, range.end.line, 0);
+             const cmd: Command = {
+                 arguments: [document, snippetRange],
+                 title: 'Send Request',
+                 command: 'rest-client.request',
+             };
+             blocks.push(new CodeLens(range, cmd));
+         }
+
+         return Promise.resolve(blocks);
+     }
+
+ }


### PR DESCRIPTION
First of all, thanks for the great extension. My team and I have been using it extensively in the last couple of months, and we consider this to be an essential part of our workflow. One useful addition would be to allow requests to be sent from `asciidoc`-files. This would enable tighter integration of writing documentation in our workflow.

I've created this PR for exactly this reason and based it on the very similar PR #933.

Happy to have your feedback on this!