### PR TITLE
feat: 指定 response 的提取方式到变量

### DIFF
--- a/src/models/httpVariableResolveResult.ts
+++ b/src/models/httpVariableResolveResult.ts
@@ -39,4 +39,5 @@ export const enum ResolveWarningMessage {
     UnsupportedBodyContentType = 'Only JSON and XML response/request body is supported to query the result',
     InvalidJSONPath = 'Invalid JSONPath query',
     InvalidXPath = 'Invalid XPath query',
+    InvalidScript = 'Invalid Script',
 }


### PR DESCRIPTION
* json: json 结构，
* xml: xml结构包括 html，使用 xpath，如 @username = {{h.response.body.#xml.//*[@id="username"]/@value}}
* js: 所有文本类型，如 @role = {{h.response.body.#js.new RegExp('角色：([^< ]+)').exec(body)[1]}}
* regex: 纯正则匹配提取，待实现
* hex: 二进制数据提取，待实现