### PR TITLE
Add support for WEBDAV verbs

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -15,7 +15,7 @@
     ],
     "folding": {
         "markers": {
-            "start": "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|curl)\\s+",
+            "start": "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|LOCK|UNLOCK|PROPFIND|PROPPATCH|COPY|MOVE|MKCOL|MKCALENDAR|ACL|SEARCH|curl)\\s+",
             "end": "^#{3,}$"
         }
     }

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
           ".http",
           ".rest"
         ],
-        "firstLine": "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE)\\s+(.*?)HTTP/[0-9\\.]+$",
+        "firstLine": "^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|LOCK|UNLOCK|PROPFIND|PROPPATCH|COPY|MOVE|MKCOL|MKCALENDAR|ACL|SEARCH)\\s+(.*?)HTTP/[0-9\\.]+$",
         "configuration": "./language-configuration.json"
       }
     ],

--- a/src/utils/curlRequestParser.ts
+++ b/src/utils/curlRequestParser.ts
@@ -19,7 +19,7 @@ export class CurlRequestParser implements RequestParser {
         let requestText = CurlRequestParser.mergeMultipleSpacesIntoSingle(
             CurlRequestParser.mergeIntoSingleLine(this.requestRawText.trim()));
         requestText = requestText
-            .replace(/(-X)(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE)/, '$1 $2')
+            .replace(/(-X)(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|LOCK|UNLOCK|PROPFIND|PROPPATCH|COPY|MOVE|MKCOL|MKCALENDAR|ACL|SEARCH)/, '$1 $2')
             .replace(/(-I|--head)(?=\s+)/, '-X HEAD');
         const parsedArguments = yargsParser(requestText);
 

--- a/src/utils/httpElementFactory.ts
+++ b/src/utils/httpElementFactory.ts
@@ -217,7 +217,7 @@ export class HttpElementFactory {
                 return;
             }
             const prefixLength = protocol.length + 2; // https: + //
-            originalElements.push(new HttpElement(`${requestUrl.substr(prefixLength)}`, ElementType.URL, '^\\s*(?:(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE)\\s+)https?\\:\\/{2}'));
+            originalElements.push(new HttpElement(`${requestUrl.substr(prefixLength)}`, ElementType.URL, '^\\s*(?:(?:GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|LOCK|UNLOCK|PROPFIND|PROPPATCH|COPY|MOVE|MKCOL|MKCALENDAR|ACL|SEARCH)\\s+)https?\\:\\/{2}'));
         });
 
         let elements: HttpElement[] = [];

--- a/src/utils/httpRequestParser.ts
+++ b/src/utils/httpRequestParser.ts
@@ -152,7 +152,7 @@ export class HttpRequestParser implements RequestParser {
         let url: string;
 
         let match: RegExpExecArray | null;
-        if (match = /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE)\s+/i.exec(line)) {
+        if (match = /^(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|CONNECT|TRACE|LOCK|UNLOCK|PROPFIND|PROPPATCH|COPY|MOVE|MKCOL|MKCALENDAR|ACL|SEARCH)\s+/i.exec(line)) {
             method = match[1];
             url = line.substr(match[0].length);
         } else {

--- a/syntaxes/http.tmLanguage.json
+++ b/syntaxes/http.tmLanguage.json
@@ -258,7 +258,7 @@
           ]
         }
       },
-      "match": "(?i)^(?:(get|post|put|delete|patch|head|options|connect|trace)\\s+)?\\s*(.+?)(?:\\s+(HTTP\\/\\S+))?$",
+      "match": "(?i)^(?:(get|post|put|delete|patch|head|options|connect|trace|lock|unlock|propfind|proppatch|copy|move|mkcol|mkcalendar|acl|search)\\s+)?\\s*(.+?)(?:\\s+(HTTP\\/\\S+))?$",
       "name": "http.requestline"
     },
     "response-line": {


### PR DESCRIPTION
This is a suggestion to address the request ( #766 ) for support of the http verbs used by webdav (and caldav).