### PR TITLE
add content type to graphql snippet

### DIFF
--- a/snippets/http.json
+++ b/snippets/http.json
@@ -38,6 +38,7 @@
         "body": [
             "POST ${1:url} HTTP/1.1",
             "X-Request-Type: GraphQL",
+            "Content-Type: application/json",
             "${2:header name}: ${3:header value}",
             "",
             "${4:body content}",


### PR DESCRIPTION
standard post request Content-Type should be set to `application/json`
ref.: https://graphql.org/learn/serving-over-http/#post-request