### PR TITLE
[Feature] add support for vscode env in dotenv

### DIFF
--- a/src/utils/httpVariableProviders/systemVariableProvider.ts
+++ b/src/utils/httpVariableProviders/systemVariableProvider.ts
@@ -189,12 +189,12 @@ export class SystemVariableProvider implements HttpVariableProvider {
     private registerDotenvVariable() {
         this.resolveFuncs.set(Constants.DotenvVariableName, async (name, document) => {
             let folderPath = path.dirname(document.fileName);
-            const { name : enviornmentName } = await EnvironmentController.getCurrentEnvironment();
+            const { name : environmentName } = await EnvironmentController.getCurrentEnvironment();
 
             let pathsFound = [false, false];
 
             while ((pathsFound = await Promise.all([
-                fs.pathExists(path.join(folderPath, `.env.${enviornmentName}`)),
+                fs.pathExists(path.join(folderPath, `.env.${environmentName}`)),
                 fs.pathExists(path.join(folderPath, '.env'))
             ])).every(result => result === false)) {
                 folderPath = path.join(folderPath, '..');
@@ -202,7 +202,7 @@ export class SystemVariableProvider implements HttpVariableProvider {
                     return { warning: ResolveWarningMessage.DotenvFileNotFound };
                 }
             }
-            const absolutePath = path.join(folderPath, pathsFound[0] ? `.env.${enviornmentName}` : '.env');
+            const absolutePath = path.join(folderPath, pathsFound[0] ? `.env.${environmentName}` : '.env');
             const groups = this.dotenvRegex.exec(name);
             if (groups !== null && groups.length === 3) {
                 const parsed = dotenv.parse(await fs.readFile(absolutePath));


### PR DESCRIPTION
This PR allows the users to create .env files for each environment that exists within their vscode settings. 

<img width="300" alt="Screenshot 2023-05-01 at 2 51 24 PM" src="https://user-images.githubusercontent.com/14203204/235510227-19321549-c8dd-4cb8-a713-6248b4980683.png">

Behavior: When walking back up the path, when either `.env` or `.env.{vscode-env}` is found, stop and prefer `.env.{vscode-env}`.

Use case:
I want to specify an auth token in gitignored env files because the repo's settings.json is checked into source control already so we cannot place them in there safely.

Closes https://github.com/Huachao/vscode-restclient/issues/740
