### PR TITLE
Change EnvironmentVariable resolution

### DIFF
--- a/src/utils/httpVariableProviders/environmentVariableProvider.ts
+++ b/src/utils/httpVariableProviders/environmentVariableProvider.ts
@@ -50,19 +50,30 @@ export class EnvironmentVariableProvider implements HttpVariableProvider {
         const variables = this._settings.environmentVariables;
         const currentEnvironmentVariables = variables[environmentName];
         const sharedEnvironmentVariables = variables[EnvironmentController.sharedEnvironmentName];
-        this.mapEnvironmentVariables(currentEnvironmentVariables, sharedEnvironmentVariables);
+
+        // Resolve mappings from shared environment
+        this.mapEnvironmentVariables('shared', sharedEnvironmentVariables, sharedEnvironmentVariables);
+        this.mapEnvironmentVariables('shared', currentEnvironmentVariables, sharedEnvironmentVariables);
+        
+        // Resolve mappings from current environment
+        this.mapEnvironmentVariables(environmentName, currentEnvironmentVariables, currentEnvironmentVariables);
         return {...sharedEnvironmentVariables, ...currentEnvironmentVariables};
     }
 
-    private mapEnvironmentVariables(current: { [key: string]: string }, shared: { [key: string]: string }) {
+    private mapEnvironmentVariables(environment: string, current: { [key: string]: string }, shared: { [key: string]: string }) {
         for (const [key, value] of Object.entries(current)) {
-            const variableRegex = /\{{2}\$shared (.+?)\}{2}/;
+            const variableRegex = new RegExp(`\\{{2}\\$${environment} (.+?)\\}{2}`);
             const match = variableRegex.exec(value);
+            
             if (!match) {
                 continue;
             }
+
             const referenceKey = match[1].trim();
-            current[key] = shared[referenceKey];
+
+            current[key] = current[key]!.replace(
+                variableRegex,
+                shared[referenceKey]!);
         }
     }
 }


### PR DESCRIPTION
Updated the environmentVariableProvider so that it supports variable resolution in all environments.
This is supposed to fix a few existing bugs and add more functionality by aligning environmentVariableResolution to be more similar to fileVariableResolution.

For example, the following settings:
```js
{
    "rest-client.environmentVariables": {
        "$shared": {
            "protocol": "https",
            "url": "{{$shared protocol}://www.demo.com",
        },
        "test": {
            "apiEndpoint": "{{$shared url}/test/api",
            "users": "{{$test apiEndpoint}}/users",
        }
    }
}
```

Before, it would resole to:
```
protocol = https
url = {{$shared protocol}://www.demo.com
apiEndpoint = {{$shared protocol}://www.demo.com
users = {{$test apiEndpoint}}/users
```

With this change it will be:
```
protocol = https
url = https://www.demo.com
apiEndpoint = https://www.demo.com/test/api
users = https://www.demo.com/test/api/users
```