### PR TITLE
[Feature] Read aad2 scopes from environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,7 +577,7 @@ System variables provide a pre-defined set of variables that can be used in any 
 
   `appOnly`: Optional. Specify `appOnly` to use make to use a client credentials flow to obtain a token. `aadV2ClientSecret` and `aadV2AppUri`must be provided as REST Client environment variables. `aadV2ClientId` and `aadV2TenantId` may also be optionally provided via the environment. `aadV2ClientId` in environment will only be used for `appOnly` calls.
 
-  `scopes:<scope[,]>`: Optional. Comma delimited list of scopes that must have consent to allow the call to be successful. Not applicable for `appOnly` calls.
+  `scopes:<scope[,]>`: Optional. Comma delimited list of scopes that must have consent to allow the call to be successful. Not applicable for `appOnly` calls. `aadV2Scopes` may optionally be provided via the environment.
 
   `tenantId:<domain|tenantId>`: Optional. Domain or tenant id for the tenant to sign in to. (`common` to determine tenant from sign in).
 

--- a/src/utils/aadV2TokenProvider.ts
+++ b/src/utils/aadV2TokenProvider.ts
@@ -188,7 +188,7 @@ class AuthParameters {
         // Update defaults based on environment
         authParameters.tenantId = (await authParameters.readEnvironmentVariable("aadV2TenantId")) || authParameters.tenantId;
 
-        let scopes = "openid,profile";
+        let scopes = (await authParameters.readEnvironmentVariable("aadV2Scopes")) || "openid,profile";
         let explicitClientId: string | undefined = undefined;
         // Parse variable parameters
         const groups = authParameters.aadV2TokenRegex.exec(name);


### PR DESCRIPTION
Hi @Huachao,
Thank you a lot for your work and such a great plugin. Looks very promising for me to use. 

I would like to suggest a very tiny PR with a feature. I found that all AAD settings can be set per environment except scopes. But on AAD, multiple app registrations can have different scopes (e.g. Dev/User.Default, Prod/User.Default, etc.). 

It would be awesome if you could approve my PR and add this feature to your extension. I wasn't able to build `vsix` package from your current master branch, so based it on a commit with tag `v0.25.0` and tested it on my local.

Thank you (;