### PR TITLE
feat(graphql): forces http header value to be lowercase

### DIFF
--- a/src/utils/httpRequestParser.ts
+++ b/src/utils/httpRequestParser.ts
@@ -82,7 +82,7 @@ export class HttpRequestParser implements RequestParser {
         removeHeader(headers, 'content-length');
 
         // check request type
-        const isGraphQlRequest = getHeader(headers, 'X-Request-Type') === 'GraphQL';
+        const isGraphQlRequest = getHeader(headers, 'X-Request-Type') === 'GraphQL'.toLowerCase();
         if (isGraphQlRequest) {
             removeHeader(headers, 'X-Request-Type');
 


### PR DESCRIPTION
While RFC2616 indicates http header field `names` are case insensitive, it leaves http header field `values` more open to interpretation, such as using the text

> Applications ought to follow "common form", where one is known or
indicated, when generating HTTP constructs, since there might exist some implementations that fail to accept anything beyond the common forms.

This is a small user experience improvement for REST Client users to prevent a negative experience by using a case sensitive value.

This is also consistent with the current code snippet for getHeader method which forces lowercase on the http header fields. 
https://github.com/Huachao/vscode-restclient/blob/80ee7d19a9c9b61691a914170dbc750ac6d182f1/src/utils/misc.ts#L12

fixes #1236