### PR TITLE
Make XDG directory specification support more convenient

### DIFF
--- a/src/utils/userDataManager.ts
+++ b/src/utils/userDataManager.ts
@@ -5,7 +5,9 @@ import { HistoricalHttpRequest } from '../models/httpRequest';
 import { JsonFileUtility } from './jsonFileUtility';
 
 const restClientDir = 'rest-client';
-const rootPath = path.join(os.homedir(), `.${restClientDir}`);
+const rootPath = process.env.VSC_REST_CLIENT_HOME !== undefined
+    ? process.env.VSC_REST_CLIENT_HOME
+    : path.join(os.homedir(), `.${restClientDir}`);
 
 function getCachePath(): string {
     if (fs.existsSync(rootPath)) {
@@ -19,13 +21,13 @@ function getCachePath(): string {
     return rootPath;
 }
 
-function getConfigPath(): string {
+function getStatePath(): string {
     if (fs.existsSync(rootPath)) {
         return rootPath;
     }
 
-    if (process.env.XDG_CONFIG_HOME !== undefined) {
-        return path.join(process.env.XDG_CONFIG_HOME, restClientDir);
+    if (process.env.XDG_STATE_HOME !== undefined) {
+        return path.join(process.env.XDG_STATE_HOME, restClientDir);
     }
 
     return rootPath;
@@ -36,7 +38,7 @@ export class UserDataManager {
     private static readonly historyItemsMaxCount = 50;
 
     private static readonly cachePath: string = getCachePath();
-    private static readonly configPath: string = getConfigPath();
+    private static readonly statePath: string = getStatePath();
 
     public static get cookieFilePath() {
         return path.join(this.cachePath, 'cookie.json');
@@ -47,7 +49,7 @@ export class UserDataManager {
     }
 
     private static get environmentFilePath() {
-        return path.join(this.configPath, 'environment.json');
+        return path.join(this.statePath, 'environment.json');
     }
 
     private static get responseSaveFolderPath() {


### PR DESCRIPTION
A follow up to [this](https://github.com/Huachao/vscode-restclient/pull/590) PR and [base-dir-spec](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html)

According to `environment.json` file content, i think, it looks like more a _**state**_, _**than**_ config, so i guess `environment.json` file should be placed in `XDG_STATE_HOME`.

Similar example: [moving state file from XDG_CONFIG_HOME to XDG_STATE_HOME](https://github.com/jesseduffield/lazygit/blob/618fe533f8c6113392eea981d03c65e6da5860bb/pkg/config/app_config.go#L292) ([context](https://github.com/jesseduffield/lazygit/pull/2936))

Also, added support of `VSC_REST_CLIENT_HOME` if single place for all user data required.