### PR TITLE
Preserve multiple `Set-Cookie` headers

### DIFF
--- a/src/controllers/historyController.ts
+++ b/src/controllers/historyController.ts
@@ -6,6 +6,7 @@ import * as path from 'path';
 import { QuickPickItem, window, workspace } from 'vscode';
 import { HistoricalHttpRequest } from '../models/httpRequest';
 import { trace } from "../utils/decorator";
+import { formatHeaders } from '../utils/misc';
 import { UserDataManager } from '../utils/userDataManager';
 
 dayjs.extend(relativeTime);
@@ -62,14 +63,7 @@ export class HistoryController {
     private async createRequestInTempFile(request: HistoricalHttpRequest): Promise<string> {
         const file = await this.createTempFile();
         let output = `${request.method.toUpperCase()} ${request.url}${EOL}`;
-        if (request.headers) {
-            for (const header in request.headers) {
-                if (request.headers.hasOwnProperty(header)) {
-                    const value = request.headers[header];
-                    output += `${header}: ${value}${EOL}`;
-                }
-            }
-        }
+        output += formatHeaders(request.headers);
         if (request.body) {
             output += `${EOL}${request.body}`;
         }

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -33,6 +33,32 @@ export function removeHeader(headers: RequestHeaders | ResponseHeaders, name: st
     }
 }
 
+export function formatHeaders(headers: RequestHeaders | ResponseHeaders): string {
+    let headerString = '';
+    for (const header in headers) {
+        if (headers.hasOwnProperty(header)) {
+            let value = headers[header];
+            // Handle set-cookie as a special case since multiple entries
+            // should appear as their own header. For example:
+            //     set-cookie: a=b
+            //     set-cookie: c=d
+            // Not:
+            //     set-cookie: a=b,c=d
+            if (header.toLowerCase() === 'set-cookie') {
+                if (typeof value === 'string') {
+                    value = [value];
+                }
+                for (const cookie of <Array<string>>value) {
+                    headerString += `${header}: ${cookie}\n`;
+                }
+            } else {
+                headerString += `${header}: ${value}\n`;
+            }
+        }
+    }
+    return headerString;
+}
+
 export function md5(text: string | Buffer): string {
     return crypto.createHash('md5').update(text).digest('hex');
 }

--- a/src/views/httpResponseTextDocumentView.ts
+++ b/src/views/httpResponseTextDocumentView.ts
@@ -1,10 +1,10 @@
 import { EOL } from 'os';
 import { languages, Position, Range, TextDocument, ViewColumn, window, workspace } from 'vscode';
-import { RequestHeaders, ResponseHeaders } from '../models/base';
 import { SystemSettings } from '../models/configurationSettings';
 import { HttpResponse } from '../models/httpResponse';
 import { PreviewOption } from '../models/previewOption';
 import { MimeUtility } from '../utils/mimeUtility';
+import { formatHeaders } from '../utils/misc';
 import { ResponseFormatUtility } from '../utils/responseFormatUtility';
 
 export class HttpResponseTextDocumentView {
@@ -49,7 +49,7 @@ export class HttpResponseTextDocumentView {
             // for add request details
             const request = response.request;
             content += `${request.method} ${request.url} HTTP/1.1${EOL}`;
-            content += this.formatHeaders(request.headers);
+            content += formatHeaders(request.headers);
             if (request.body) {
                 if (typeof request.body !== 'string') {
                     request.body = 'NOTE: Request Body From Is File Not Shown';
@@ -62,7 +62,7 @@ export class HttpResponseTextDocumentView {
 
         if (previewOption !== PreviewOption.Body) {
             content += `HTTP/${response.httpVersion} ${response.statusCode} ${response.statusMessage}${EOL}`;
-            content += this.formatHeaders(response.headers);
+            content += formatHeaders(response.headers);
         }
 
         if (previewOption !== PreviewOption.Headers) {
@@ -71,15 +71,6 @@ export class HttpResponseTextDocumentView {
         }
 
         return content;
-    }
-
-    private formatHeaders(headers: RequestHeaders | ResponseHeaders): string {
-        let headerString = '';
-        for (const header in headers) {
-            const value = headers[header] as string;
-            headerString += `${header}: ${value}${EOL}`;
-        }
-        return headerString;
     }
 
     private getVSCodeDocumentLanguageId(response: HttpResponse) {


### PR DESCRIPTION
This PR ungroups `Set-Cookie` headers since each header should appear independently. According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie):

> To send multiple cookies, multiple `Set-Cookie` headers should be sent in the same response.

For example, the following is correct:

```
Set-Cookie: a=b
Set-Cookie: c=d
```

While the following is incorrect:

```
Set-Cookie: a=b,c=d
```

This PR achieves this by:
- Adding an exported `formatHeaders` function in `utils/misc.ts` that treats `set-cookie` as a special case.
- Removing the `private formatHeaders` function from `HttpResponseTextDocumentView` and updating all calls to use the new utility `formatHeaders` function.
- Removing the `private static formatHeaders` function from `HttpResponseWebview` and updating all calls to use the new utility `formatHeaders` function.
- Updating `getFullResponseString` in `HttpResponseWebview` to use the new utility `formatHeaders` function.
- Updating `createRequestInTempFile` in `HistoryController` to  use the new utility `formatHeaders` function.

Fixes #722