### PR TITLE
Add built-in support for Oidc tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ REST Client allows you to send HTTP request and view the response in Visual Stud
       + `{{$processEnv [%]envVarName}}`
       + `{{$dotenv [%]variableName}}`
       + `{{$aadToken [new] [public|cn|de|us|ppe] [<domain|tenantId>] [aud:<domain|tenantId>]}}`
+      + `{{$oidcAccessToken  [new]  [<clientId:<clientId>] [<callbackPort:<callbackPort>] [authorizeEndpoint:<authorizeEndpoint}] [tokenEndpoint:<tokenEndpoint}] [scopes:<scopes}] [audience:<audience}]}`
     - Easily create/update/delete environments and environment variables in setting file
     - File variables can reference both custom and system variables
     - Support environment switch
@@ -586,6 +587,22 @@ System variables provide a pre-defined set of variables that can be used in any 
 
   `clientId:<clientid>`: Optional. Identifier of the application registration to use to obtain the token. Default uses an application registration created specifically for this plugin.
 
+* `{{$oidcAccessToken  [new]  [<clientId:<clientId>] [<callbackPort:<callbackPort>] [authorizeEndpoint:<authorizeEndpoint}] [tokenEndpoint:<tokenEndpoint}] [scopes:<scopes}] [audience:<audience}]}`: Add an Oidc Identity Server token based on the following options (must be specified in order):
+
+  `new`: Optional. Specify `new` to force re-authentication and get a new token for the client. Default: Reuse previous token for clientId from an in-memory cache. Expired tokens are refreshed automatically. (Restart Visual Studio Code to clear the cache.)
+
+  `clientId:<clientid>`: Optional. Identifier of the application registration to use to obtain the token.
+
+  `callbackPort:<callbackPort>`: Optional. Port to use for the local callback server. Default: 7777 (random port).
+
+  `authorizeEndpoint:<authorizeEndpoint>`: The authorization endpoint to use. 
+
+  `tokenEndpoint:<tokenEndpoint>`: The token endpoint to use. 
+
+  `scopes:<scope[,]>`: Optional. Comma delimited list of scopes that must have consent to allow the call to be successful. 
+
+  `audience:<audience>`: Optional.
+   
 * `{{$guid}}`: Add a RFC 4122 v4 UUID
 * `{{$processEnv [%]envVarName}}`: Allows the resolution of a local machine environment variable to a string value. A typical use case is for secret keys that you don't want to commit to source control.
 For example: Define a shell environment variable in `.bashrc` or similar on windows

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "node-jws": "^0.1.4",
         "open": "^10.1.0",
         "pretty-data": "^0.40.0",
+        "sanitize-html": "^2.13.0",
         "tough-cookie": "^4.1.3",
         "tough-cookie-file-store": "^2.0.3",
         "uuid": "^3.3.2",
@@ -1101,6 +1102,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-browser": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
@@ -1182,6 +1192,61 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/dotenv": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
@@ -1254,6 +1319,18 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/envinfo": {
@@ -1733,6 +1810,25 @@
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+      "integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
+        "entities": "^4.4.0"
       }
     },
     "node_modules/http-cache-semantics": {
@@ -2807,6 +2903,24 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
     },
+    "node_modules/nanoid": {
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/neo-async": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
@@ -2935,6 +3049,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -2977,10 +3097,10 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -3023,6 +3143,34 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.40",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.40.tgz",
+      "integrity": "sha512-YF2kKIUzAofPMpfH6hOi2cGnv/HrUlfucspc7pDyvv7kGdqXrfj8SCl/t8owkEgKEuu8ZcRjSOxFxVLqwChZ2Q==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.7",
+        "picocolors": "^1.0.1",
+        "source-map-js": "^1.2.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/pretty-data": {
@@ -3247,6 +3395,41 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "node_modules/sanitize-html": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
+      "integrity": "sha512-Xff91Z+4Mz5QiNSLdLWwjgBDm5b1RU6xBT0+12rapjiaR7SwfRdjw8f+6Rir2MXKLrDicRFHdb51hGOAxmsUIA==",
+      "license": "MIT",
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^8.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/schema-utils": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.3.0.tgz",
@@ -3319,6 +3502,15 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
       "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+      "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/source-map-support": {
       "version": "0.5.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
-        "@opentelemetry/tracing": "^0.24.0",
         "adal-node": "^0.2.4",
         "applicationinsights": "^1.0.5",
         "aws4": "^1.9.1",
@@ -200,88 +199,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@opentelemetry/api": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/core": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
-      "integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "semver": "^7.1.3"
-      },
-      "engines": {
-        "node": ">=8.5.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-      }
-    },
-    "node_modules/@opentelemetry/core/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@opentelemetry/resources": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
-      "integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
-      }
-    },
-    "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
-      "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/@opentelemetry/tracing": {
-      "version": "0.24.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
-      "integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
-      "deprecated": "Package renamed to @opentelemetry/sdk-trace-base",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@opentelemetry/core": "0.24.0",
-        "@opentelemetry/resources": "0.24.0",
-        "@opentelemetry/semantic-conventions": "0.24.0",
-        "lodash.merge": "^4.6.2"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "peerDependencies": {
-        "@opentelemetry/api": "^1.0.1"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -2305,12 +2222,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-node": "^2.10.0",
         "@opentelemetry/tracing": "^0.24.0",
         "adal-node": "^0.2.4",
         "applicationinsights": "^1.0.5",
@@ -59,38 +58,6 @@
       },
       "engines": {
         "vscode": "^1.81.0"
-      }
-    },
-    "node_modules/@azure/msal-common": {
-      "version": "14.13.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.13.0.tgz",
-      "integrity": "sha512-b4M/tqRzJ4jGU91BiwCsLTqChveUEyFK3qY2wGfZ0zBswIBZjAxopx5CYt5wzZFKuN15HqRDYXQbztttuIC3nA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@azure/msal-node": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
-      "integrity": "sha512-JxsSE0464a8IA/+q5EHKmchwNyUFJHtCH00tSXsLaOddwLjG6yVvTH6lGgPcWMhO7YWUXj/XVgVgeE9kZtsPUQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@azure/msal-common": "14.13.0",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@azure/msal-node/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2263,46 +2230,6 @@
         "node": ">=6.0"
       }
     },
-    "node_modules/jsonwebtoken": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
-      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
-      "license": "MIT",
-      "dependencies": {
-        "jws": "^3.2.2",
-        "lodash.includes": "^4.3.0",
-        "lodash.isboolean": "^3.0.3",
-        "lodash.isinteger": "^4.0.4",
-        "lodash.isnumber": "^3.0.3",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "lodash.once": "^4.0.0",
-        "ms": "^2.1.1",
-        "semver": "^7.5.4"
-      },
-      "engines": {
-        "node": ">=12",
-        "npm": ">=6"
-      }
-    },
-    "node_modules/jsonwebtoken/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/jsonwebtoken/node_modules/semver": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
-      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -2379,52 +2306,10 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "node_modules/lodash.includes": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isboolean": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isinteger": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isnumber": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.isstring": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT"
-    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "license": "MIT"
-    },
-    "node_modules/lodash.once": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
     },
     "node_modules/log-symbols": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
+        "@azure/msal-node": "^2.10.0",
+        "@opentelemetry/tracing": "^0.24.0",
         "adal-node": "^0.2.4",
         "applicationinsights": "^1.0.5",
         "aws4": "^1.9.1",
@@ -29,6 +31,9 @@
         "jsonc-parser": "^2.0.2",
         "jsonpath-plus": "^0.20.1",
         "mime-types": "^2.1.14",
+        "node-fetch": "^2.6.7",
+        "node-jws": "^0.1.4",
+        "open": "^10.1.0",
         "pretty-data": "^0.40.0",
         "tough-cookie": "^4.1.3",
         "tough-cookie-file-store": "^2.0.3",
@@ -40,8 +45,10 @@
       "devDependencies": {
         "@types/aws4": "^1.5.1",
         "@types/fs-extra": "^5.0.4",
+        "@types/jws": "^3.2.10",
         "@types/mocha": "^5.2.6",
         "@types/node": "^18.0.0",
+        "@types/node-fetch": "^2.6.11",
         "@types/vscode": "^1.81.0",
         "mocha": "^10.4.0",
         "ts-loader": "^7.0.5",
@@ -52,6 +59,38 @@
       },
       "engines": {
         "vscode": "^1.81.0"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.13.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.13.0.tgz",
+      "integrity": "sha512-b4M/tqRzJ4jGU91BiwCsLTqChveUEyFK3qY2wGfZ0zBswIBZjAxopx5CYt5wzZFKuN15HqRDYXQbztttuIC3nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.10.0.tgz",
+      "integrity": "sha512-JxsSE0464a8IA/+q5EHKmchwNyUFJHtCH00tSXsLaOddwLjG6yVvTH6lGgPcWMhO7YWUXj/XVgVgeE9kZtsPUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.13.0",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -196,6 +235,88 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-0.24.0.tgz",
+      "integrity": "sha512-KpsfxBbFTZT9zaB4Es/fFLbvSzVl9Io/8UUu/TYl4/HgqkmyVInNlWTgRiKyz9nsHzFpGP1kdZJj+YIut0IFsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "0.24.0",
+        "semver": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=8.5.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/core/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-0.24.0.tgz",
+      "integrity": "sha512-uEr2m13IRkjQAjX6fsYqJ21aONCspRvuQunaCl8LbH1NS1Gj82TuRUHF6TM82ulBPK8pU+nrrqXKuky2cMcIzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "0.24.0",
+        "@opentelemetry/semantic-conventions": "0.24.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-0.24.0.tgz",
+      "integrity": "sha512-a/szuMQV0Quy0/M7kKdglcbRSoorleyyOwbTNNJ32O+RBN766wbQlMTvdimImTmwYWGr+NJOni1EcC242WlRcA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/tracing": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/tracing/-/tracing-0.24.0.tgz",
+      "integrity": "sha512-sTLEs1SIon3xV8vLe53PzfbU0FahoxL9NPY/CYvA1mwGbMu4zHkHAjqy1Tc8JmqRrfa+XrHkmzeSM4hrvloBaA==",
+      "deprecated": "Package renamed to @opentelemetry/sdk-trace-base",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "0.24.0",
+        "@opentelemetry/resources": "0.24.0",
+        "@opentelemetry/semantic-conventions": "0.24.0",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.1"
+      }
+    },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
@@ -284,6 +405,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
+    "node_modules/@types/jws": {
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/@types/jws/-/jws-3.2.10.tgz",
+      "integrity": "sha512-cOevhttJmssERB88/+XvZXvsq5m9JLKZNUiGfgjUb5lcPRdV2ZQciU6dU76D/qXXFYpSqkP3PrSg4hMTiafTZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/keyv": {
       "version": "3.1.4",
       "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
@@ -304,6 +435,17 @@
       "integrity": "sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==",
       "dependencies": {
         "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@types/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-24xFj9R5+rfQJLRyM56qh+wnVSYhyXC2tkoBndtY0U+vubqNsYXGjufB2nn8Q6gt0LrARwL6UBtMCSVCwl4B1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "form-data": "^4.0.0"
       }
     },
     "node_modules/@types/responselike": {
@@ -819,6 +961,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
@@ -1060,12 +1217,52 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/default-browser": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.2.1.tgz",
+      "integrity": "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.0.tgz",
+      "integrity": "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/defer-to-connect": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
       "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -1392,6 +1589,21 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/from": {
@@ -1803,6 +2015,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -1822,6 +2049,24 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-number": {
@@ -1877,6 +2122,21 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
+      "integrity": "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2003,6 +2263,46 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jsonwebtoken/node_modules/semver": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.2.tgz",
+      "integrity": "sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jwa": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
@@ -2078,6 +2378,54 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
     },
     "node_modules/log-symbols": {
       "version": "4.1.0",
@@ -2669,6 +3017,32 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-jws": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/node-jws/-/node-jws-0.1.4.tgz",
+      "integrity": "sha512-oJk6X0kad7VOms/uUVagHskJ8ENP2tqPAReIBT1R7ulf0BkBmNJgyMK7kFhwG9w55KLZj17bWzNbZpnkbZjvMQ==",
+      "license": "MIT"
+    },
     "node_modules/node-releases": {
       "version": "2.0.14",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
@@ -2701,6 +3075,24 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/open": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
+      "integrity": "sha512-mnkeQ1qP5Ue2wd+aivTD3NHd/lZ96Lu0jgf0pwktLPtx6cTZiH7tyeGRRHs0zX0rbrahXPnXlUnbeXyaBBuIaw==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.2.1",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-cancelable": {
@@ -3018,6 +3410,18 @@
       "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dependencies": {
         "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.0.0.tgz",
+      "integrity": "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3401,6 +3805,12 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/ts-loader": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-7.0.5.tgz",
@@ -3681,6 +4091,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/webpack": {
       "version": "5.91.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.91.0.tgz",
@@ -3825,6 +4241,16 @@
       "dev": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -475,6 +475,48 @@
           "scope": "resource",
           "description": "Preview response in untitled document if set to true, otherwise displayed in html view"
         },
+        "rest-client.oidcCertificates": {
+          "type": "object",
+          "default": {},
+          "scope": "resource",
+          "description": "Certificate paths for Oidc callback server",
+          "pattern": "^(?!http(s?)://)",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "object",
+                "default": {},
+                "description": "Certifcate paths for Oidc callback server",
+                "properties": {
+                  "cert": {
+                    "type": "string",
+                    "description": "Absolute or relative path of Public x509 certificate"
+                  },
+                  "key": {
+                    "type": "string",
+                    "description": "Absolute or relative path of Private key"
+                  },
+                  "pfx": {
+                    "type": "string",
+                    "description": "Absolute or relative path of PKCS #12 certificate"
+                  },
+                  "passphrase": {
+                    "type": "string",
+                    "description": "[Optional] A string of passphrase for the private key or pfx"
+                  }
+                },
+                "dependencies": {
+                  "cert": [
+                    "key"
+                  ],
+                  "key": [
+                    "cert"
+                  ]
+                }
+              }
+            ]
+          }
+        },
         "rest-client.certificates": {
           "type": "object",
           "default": {},

--- a/package.json
+++ b/package.json
@@ -475,6 +475,13 @@
           "scope": "resource",
           "description": "Preview response in untitled document if set to true, otherwise displayed in html view"
         },
+        "rest-client.oidcScopes": {
+          "type": "array",
+          "default": [],
+          "scope": "resource",
+          "description": "Scopes to be used by the OIDC client, default: [openid profile email]"
+        },
+
         "rest-client.oidcCertificates": {
           "type": "object",
           "default": {},

--- a/package.json
+++ b/package.json
@@ -673,8 +673,6 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
-    "@azure/msal-node": "^2.10.0",
-    "@opentelemetry/tracing": "^0.24.0",
     "adal-node": "^0.2.4",
     "applicationinsights": "^1.0.5",
     "aws4": "^1.9.1",

--- a/package.json
+++ b/package.json
@@ -660,8 +660,10 @@
   "devDependencies": {
     "@types/aws4": "^1.5.1",
     "@types/fs-extra": "^5.0.4",
+    "@types/jws": "^3.2.10",
     "@types/mocha": "^5.2.6",
     "@types/node": "^18.0.0",
+    "@types/node-fetch": "^2.6.11",
     "@types/vscode": "^1.81.0",
     "mocha": "^10.4.0",
     "ts-loader": "^7.0.5",
@@ -671,6 +673,8 @@
     "webpack-cli": "^5.0.1"
   },
   "dependencies": {
+    "@azure/msal-node": "^2.10.0",
+    "@opentelemetry/tracing": "^0.24.0",
     "adal-node": "^0.2.4",
     "applicationinsights": "^1.0.5",
     "aws4": "^1.9.1",
@@ -691,6 +695,9 @@
     "jsonc-parser": "^2.0.2",
     "jsonpath-plus": "^0.20.1",
     "mime-types": "^2.1.14",
+    "node-fetch": "^2.6.7",
+    "node-jws": "^0.1.4",
+    "open": "^10.1.0",
     "pretty-data": "^0.40.0",
     "tough-cookie": "^4.1.3",
     "tough-cookie-file-store": "^2.0.3",

--- a/package.json
+++ b/package.json
@@ -481,7 +481,6 @@
           "scope": "resource",
           "description": "Scopes to be used by the OIDC client, default: [openid profile email]"
         },
-
         "rest-client.oidcCertificates": {
           "type": "object",
           "default": {},
@@ -746,6 +745,7 @@
     "node-jws": "^0.1.4",
     "open": "^10.1.0",
     "pretty-data": "^0.40.0",
+    "sanitize-html": "^2.13.0",
     "tough-cookie": "^4.1.3",
     "tough-cookie-file-store": "^2.0.3",
     "uuid": "^3.3.2",

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -25,7 +25,7 @@ export const AzureActiveDirectoryV2TokenVariableName = "$aadV2Token";
 export const AzureActiveDirectoryV2TokenDescription = "Prompts to sign in to Azure AD V2 and adds the token to the request";
 
 export const OidcVariableName = "$oidcAccessToken";
-export const OidcDescription = "Prompts to sign in to an Oidc provider  and adds the token to the request";
+export const OidcDescription = "Prompts to sign in to an Oidc provider and adds the token to the request";
 export const OIdcForceNewOption = "new";
 
 

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -24,6 +24,11 @@ export const AzureActiveDirectoryDescription = "Prompts to sign in to Azure AD a
 export const AzureActiveDirectoryV2TokenVariableName = "$aadV2Token";
 export const AzureActiveDirectoryV2TokenDescription = "Prompts to sign in to Azure AD V2 and adds the token to the request";
 
+export const OidcVariableName = "$oidcAccessToken";
+export const OidcDescription = "Prompts to sign in to an Oidc provider  and adds the token to the request";
+export const OIdcForceNewOption = "new";
+
+
 /**
  * NOTE: The client id represents an AAD app people sign in to. The client id is sent to AAD to indicate what app
  * is requesting a token for the user. When the user signs in, AAD shows the name of the app to confirm the user is

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -34,6 +34,7 @@ export interface IRestClientSettings {
     readonly mimeAndFileExtensionMapping: { [key: string]: string };
     readonly previewResponseInUntitledDocument: boolean;
     readonly hostCertificates: HostCertificates;
+    readonly oidcCertificates: HostCertificates;
     readonly suppressResponseBodyContentTypeValidationWarning: boolean;
     readonly previewOption: PreviewOption;
     readonly disableHighlightResponseBodyForLargeResponse: boolean;
@@ -68,6 +69,7 @@ export class SystemSettings implements IRestClientSettings {
     private _mimeAndFileExtensionMapping: { [key: string]: string };
     private _previewResponseInUntitledDocument: boolean;
     private _hostCertificates: HostCertificates;
+    private _oidcCertificates: HostCertificates;
     private _suppressResponseBodyContentTypeValidationWarning: boolean;
     private _previewOption: PreviewOption;
     private _disableHighlightResponseBodyForLargeResponse: boolean;
@@ -149,6 +151,10 @@ export class SystemSettings implements IRestClientSettings {
 
     public get hostCertificates() {
         return this._hostCertificates;
+    }
+
+    public get oidcCertificates() {
+        return this._oidcCertificates;
     }
 
     public get suppressResponseBodyContentTypeValidationWarning() {
@@ -268,6 +274,7 @@ export class SystemSettings implements IRestClientSettings {
         this._previewColumn = this.parseColumn(restClientSettings.get<string>("previewColumn", "two"));
         this._previewResponsePanelTakeFocus = restClientSettings.get<boolean>("previewResponsePanelTakeFocus", true);
         this._hostCertificates = restClientSettings.get<HostCertificates>("certificates", {});
+        this._oidcCertificates = Object.assign({}, restClientSettings.get<HostCertificates>("oidcCertificates", {}));
         this._disableHighlightResponseBodyForLargeResponse = restClientSettings.get<boolean>("disableHighlightResponseBodyForLargeResponse", true);
         this._disableAddingHrefLinkForLargeResponse = restClientSettings.get<boolean>("disableAddingHrefLinkForLargeResponse", true);
         this._largeResponseBodySizeLimitInMB = restClientSettings.get<number>("largeResponseBodySizeLimitInMB", 5);
@@ -388,6 +395,11 @@ export class RestClientSettings implements IRestClientSettings {
     public get previewResponseInUntitledDocument() {
         return this.systemSettings.previewResponseInUntitledDocument;
     }
+
+    public get oidcCertificates() {
+        return this.systemSettings.oidcCertificates;
+    }
+
 
     public get hostCertificates() {
         return this.systemSettings.hostCertificates;

--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -35,6 +35,7 @@ export interface IRestClientSettings {
     readonly previewResponseInUntitledDocument: boolean;
     readonly hostCertificates: HostCertificates;
     readonly oidcCertificates: HostCertificates;
+    readonly oidcScopes: string[];
     readonly suppressResponseBodyContentTypeValidationWarning: boolean;
     readonly previewOption: PreviewOption;
     readonly disableHighlightResponseBodyForLargeResponse: boolean;
@@ -70,6 +71,7 @@ export class SystemSettings implements IRestClientSettings {
     private _previewResponseInUntitledDocument: boolean;
     private _hostCertificates: HostCertificates;
     private _oidcCertificates: HostCertificates;
+    private _oidcScopes: string[];
     private _suppressResponseBodyContentTypeValidationWarning: boolean;
     private _previewOption: PreviewOption;
     private _disableHighlightResponseBodyForLargeResponse: boolean;
@@ -155,6 +157,10 @@ export class SystemSettings implements IRestClientSettings {
 
     public get oidcCertificates() {
         return this._oidcCertificates;
+    }
+
+    public get oidcScopes() {
+        return this._oidcScopes;
     }
 
     public get suppressResponseBodyContentTypeValidationWarning() {
@@ -275,6 +281,7 @@ export class SystemSettings implements IRestClientSettings {
         this._previewResponsePanelTakeFocus = restClientSettings.get<boolean>("previewResponsePanelTakeFocus", true);
         this._hostCertificates = restClientSettings.get<HostCertificates>("certificates", {});
         this._oidcCertificates = Object.assign({}, restClientSettings.get<HostCertificates>("oidcCertificates", {}));
+        this._oidcScopes = restClientSettings.get<string[]>("oidcScopes", ['openid', 'profile', 'email']);
         this._disableHighlightResponseBodyForLargeResponse = restClientSettings.get<boolean>("disableHighlightResponseBodyForLargeResponse", true);
         this._disableAddingHrefLinkForLargeResponse = restClientSettings.get<boolean>("disableAddingHrefLinkForLargeResponse", true);
         this._largeResponseBodySizeLimitInMB = restClientSettings.get<number>("largeResponseBodySizeLimitInMB", 5);
@@ -400,6 +407,9 @@ export class RestClientSettings implements IRestClientSettings {
         return this.systemSettings.oidcCertificates;
     }
 
+    public get oidcScopes() {
+        return this.systemSettings.oidcScopes;
+    }
 
     public get hostCertificates() {
         return this.systemSettings.hostCertificates;

--- a/src/utils/auth/oidcClient.ts
+++ b/src/utils/auth/oidcClient.ts
@@ -102,7 +102,7 @@ export class CodeLoopbackClient {
 
       try {
         const certificates = this.getSslCertificate(settings);
-        if (certificates && certificates.cert && certificates.key) {
+        if (certificates && (certificates.cert && certificates.key || certificates.pfx)) {
           const options: SecureContextOptions = {
             cert: certificates?.cert,
             key: certificates?.key,

--- a/src/utils/auth/oidcClient.ts
+++ b/src/utils/auth/oidcClient.ts
@@ -98,11 +98,11 @@ export class CodeLoopbackClient {
         resolve({ url, ...authCodeResponse });
       };
 
-      const settings = SystemSettings.Instance as any;
+      const settings = SystemSettings.Instance as IRestClientSettings;
 
       try {
         const certificates = this.getSslCertificate(settings);
-        if (certificates) {
+        if (certificates && certificates.cert && certificates.key) {
           const options: SecureContextOptions = {
             cert: certificates?.cert,
             key: certificates?.key,
@@ -534,23 +534,10 @@ export class OidcClient {
    * @param scopes
    */
   private getScopes(scopes: string[] = []): string[] {
-    const modifiedScopes = [...scopes];
-
-    // if (!modifiedScopes.includes('offline_access')) {
-    //   modifiedScopes.push('offline_access');
-    // }
-
-    if (!modifiedScopes.includes('openid')) {
-      modifiedScopes.push('openid');
-    }
-    if (!modifiedScopes.includes('profile')) {
-      modifiedScopes.push('profile');
-    }
-    if (!modifiedScopes.includes('email')) {
-      modifiedScopes.push('email');
-    }
-
-    return modifiedScopes.sort();
+    const settings = SystemSettings.Instance as IRestClientSettings;
+    
+    let modifiedScopes = [...(settings.oidcScopes ?? []), ...scopes];
+    return Array.from(new Set(modifiedScopes.sort()));
   }
 }
 

--- a/src/utils/auth/oidcClient.ts
+++ b/src/utils/auth/oidcClient.ts
@@ -1,0 +1,439 @@
+import { ILoopbackClient, ServerAuthorizationCodeResponse } from "@azure/msal-node";
+import * as crypto from 'crypto';
+import * as http from "http";
+import * as jws from 'jws';
+import fetch from 'node-fetch';
+import { v4 as uuid } from 'uuid';
+import { env, Uri, window } from "vscode";
+import { MemoryCache } from '../memoryCache';
+
+export class CodeLoopbackClient implements ILoopbackClient {
+  port: number = 0; // default port, which will be set to a random available port
+  private server!: http.Server;
+
+  private constructor(port: number = 0) {
+    this.port = port;
+  }
+
+  /**
+   * Initializes a loopback server with an available port
+   * @param preferredPort
+   * @param logger
+   * @returns
+   */
+  static async initialize(preferredPort: number | undefined): Promise<CodeLoopbackClient> {
+    const loopbackClient = new CodeLoopbackClient();
+
+    if (preferredPort === 0 || preferredPort === undefined) {
+      return loopbackClient;
+    }
+    const isPortAvailable = await loopbackClient.isPortAvailable(preferredPort);
+
+    if (isPortAvailable) {
+      loopbackClient.port = preferredPort;
+    }
+
+    return loopbackClient;
+  }
+
+  /**
+   * Spins up a loopback server which returns the server response when the localhost redirectUri is hit
+   * @param successTemplate
+   * @param errorTemplate
+   * @returns
+   */
+  async listenForAuthCode(successTemplate?: string, errorTemplate?: string): Promise<ServerAuthorizationCodeResponse & { url: string }> {
+    if (!!this.server) {
+      throw new Error('Loopback server already exists. Cannot create another.');
+    }
+
+    const authCodeListener = new Promise<ServerAuthorizationCodeResponse & { url: string }>((resolve, reject) => {
+      this.server = http.createServer(async (req: http.IncomingMessage, res: http.ServerResponse) => {
+        const url = req.url;
+        if (!url) {
+          res.end(errorTemplate || "Error occurred loading redirectUrl");
+          reject(new Error('Loopback server callback was invoked without a url. This is unexpected.'));
+          return;
+        } else if (url === "/") {
+          res.end(successTemplate || "Auth code was successfully acquired. You can close this window now.");
+          return;
+        }
+
+        const authCodeResponse = CodeLoopbackClient.getDeserializedQueryString(url);
+        if (authCodeResponse.code) {
+          const redirectUri = await this.getRedirectUri();
+          res.writeHead(302, { location: redirectUri }); // Prevent auth code from being saved in the browser history
+          res.end();
+        }
+        resolve({ url, ...authCodeResponse });
+      });
+      this.server.listen(this.port);
+    });
+
+    // Wait for server to be listening
+    await new Promise<void>((resolve) => {
+      let ticks = 0;
+      const id = setInterval(() => {
+        if ((5000 / 100) < ticks) {
+          throw new Error('Timed out waiting for auth code listener to be registered.');
+        }
+
+        if (this.server.listening) {
+          clearInterval(id);
+          resolve();
+        }
+        ticks++;
+      }, 100);
+    });
+
+    return authCodeListener;
+  }
+
+  /**
+   * Get the port that the loopback server is running on
+   * @returns
+   */
+  getRedirectUri(): string {
+    if (!this.server) {
+      throw new Error('No loopback server exists yet.');
+    }
+
+    const address = this.server.address();
+    if (!address || typeof address === "string" || !address.port) {
+      this.closeServer();
+      throw new Error('Loopback server address is not type string. This is unexpected.');
+    }
+
+    const port = address && address.port;
+
+    return `http://localhost:${port}`;
+  }
+
+  /**
+   * Close the loopback server
+   */
+  closeServer(): void {
+    if (!!this.server) {
+      this.server.close();
+    }
+  }
+
+  /**
+   * Attempts to create a server and listen on a given port
+   * @param port
+   * @returns
+   */
+  isPortAvailable(port: number): Promise<boolean> {
+    return new Promise(resolve => {
+      const server = http.createServer()
+        .listen(port, () => {
+          server.close();
+          resolve(true);
+        })
+        .on("error", () => {
+          resolve(false);
+        });
+    });
+  }
+
+  /**
+   * Returns URL query string as server auth code response object.
+   */
+  static getDeserializedQueryString(
+    query: string
+  ): ServerAuthorizationCodeResponse {
+    // Check if given query is empty
+    if (!query) {
+      return {};
+    }
+    // Strip the ? symbol if present
+    const parsedQueryString = this.parseQueryString(query);
+    // If ? symbol was not present, above will return empty string, so give original query value
+    const deserializedQueryString: ServerAuthorizationCodeResponse =
+      this.queryStringToObject(
+        parsedQueryString || query
+      );
+    // Check if deserialization didn't work
+    if (!deserializedQueryString) {
+      throw "Unable to deserialize query string";
+    }
+    return deserializedQueryString;
+  }
+
+  /**
+   * Parses query string from given string. Returns empty string if no query symbol is found.
+   * @param queryString
+   */
+  static parseQueryString(queryString: string): string {
+    const queryIndex1 = queryString.indexOf("?");
+    const queryIndex2 = queryString.indexOf("/?");
+    if (queryIndex2 > -1) {
+      return queryString.substring(queryIndex2 + 2);
+    } else if (queryIndex1 > -1) {
+      return queryString.substring(queryIndex1 + 1);
+    }
+    return "";
+  }
+
+  /**
+   * Parses string into an object.
+   *
+   * @param query
+   */
+  static queryStringToObject(query: string): ServerAuthorizationCodeResponse {
+    const obj: { [key: string]: string } = {};
+    const params = query.split("&");
+    const decode = (s: string) => decodeURIComponent(s.replace(/\+/g, " "));
+    params.forEach((pair) => {
+      if (pair.trim()) {
+        const [key, value] = pair.split(/=(.+)/g, 2); // Split on the first occurence of the '=' character
+        if (key && value) {
+          obj[decode(key)] = decode(value);
+        }
+      }
+    });
+    return obj as ServerAuthorizationCodeResponse;
+  }
+}
+
+export const CALLBACK_PORT = 7777;
+
+export const remoteOutput = window.createOutputChannel("oidc");
+
+interface TokenInformation {
+  access_token: string;
+  refresh_token: string;
+}
+
+export class OidcClient {
+  private _tokenInformation: TokenInformation | undefined;
+  private _pendingStates: string[] = [];
+  private _codeVerfifiers = new Map<string, string>();
+  private _scopes = new Map<string, string[]>();
+
+  constructor(private clientId: string,
+    private callbackPort: number,
+    private authorizeEndpoint: string,
+    private tokenEndpoint: string,
+    private scopes: string,
+    private audience: string,
+  ) {
+  }
+
+  public static async getAccessToken(forceNew: boolean, clientId: string, callbackPort: number,
+    authorizeEndpoint: string,
+    tokenEndpoint: string,
+    scopes: string,
+    audience: string,): Promise<string | undefined> {
+    const key = `${clientId}-${callbackPort}-${authorizeEndpoint}-${tokenEndpoint}-${scopes}-${audience}`;
+    const cache = MemoryCache.createOrGet<OidcClient>('oidc');
+
+    const client = cache.get(key) ?? new OidcClient(clientId, callbackPort, authorizeEndpoint, tokenEndpoint, scopes, audience);
+    cache.set(key, client);
+    if (forceNew) {
+      client.cleanupTokenCache();
+    }
+
+    return client.getAccessToken();
+  }
+
+  public cleanupTokenCache() {
+    this._tokenInformation = undefined;
+  }
+
+  get redirectUri() {
+    return `http://localhost:${this.callbackPort ?? 7777}`;
+  }
+
+  public async getAccessToken(): Promise<string | undefined> {
+    if (this._tokenInformation?.access_token) {
+      const { payload } = jws.decode(this._tokenInformation.access_token) ?? {};
+      const payloadJson = JSON.parse(payload);
+      if (payloadJson.exp && payloadJson.exp > Date.now() / 1000) {
+        return this._tokenInformation.access_token;
+      } else {
+        return this.getAccessTokenByRefreshToken(this._tokenInformation.refresh_token, this.clientId).then((resp) => {
+          this._tokenInformation = resp;
+          return resp.access_token;
+        });
+      }
+    }
+
+    const nonceId = uuid();
+
+    // Retrieve all required scopes
+    const scopes = this.getScopes((this.scopes ?? "").split(' '));
+
+    const codeVerifier = toBase64UrlEncoding(crypto.randomBytes(32));
+    const codeChallenge = toBase64UrlEncoding(sha256(codeVerifier));
+
+    let callbackUri = await env.asExternalUri(Uri.parse(this.redirectUri));
+
+    remoteOutput.appendLine(`Callback URI: ${callbackUri.toString(true)}`);
+
+    const callbackQuery = new URLSearchParams(callbackUri.query);
+    const stateId = callbackQuery.get('state') || nonceId;
+
+    remoteOutput.appendLine(`State ID: ${stateId}`);
+    remoteOutput.appendLine(`Nonce ID: ${nonceId}`);
+
+    callbackQuery.set('state', encodeURIComponent(stateId));
+    callbackQuery.set('nonce', encodeURIComponent(nonceId));
+    callbackUri = callbackUri.with({
+      query: callbackQuery.toString()
+    });
+
+    this._pendingStates.push(stateId);
+    this._codeVerfifiers.set(stateId, codeVerifier);
+    this._scopes.set(stateId, scopes);
+
+    const params = [
+      ['response_type', "code"],
+      ['client_id', this.clientId],
+      ['redirect_uri', this.redirectUri],
+      ['state', stateId],
+      ['scope', scopes.join(' ')],
+      ['prompt', "login"],
+      ['code_challenge_method', 'S256'],
+      ['code_challenge', codeChallenge],
+    ];
+
+    if (this.audience) {
+      params.push(['resource', this.audience]);
+    }
+
+    const searchParams = new URLSearchParams(params as [string, string][]);
+
+    const uri = Uri.parse(`${this.authorizeEndpoint}?${searchParams.toString()}`);
+
+    remoteOutput.appendLine(`Login URI: ${uri.toString(true)}`);
+
+    const loopbackClient = await CodeLoopbackClient.initialize(this.callbackPort);
+
+    
+    try {
+      await env.openExternal(uri);
+      const callBackResp = await loopbackClient.listenForAuthCode();
+      const codeExchangePromise = this._handleCallback(Uri.parse(callBackResp.url));
+
+    const resp = await Promise.race([
+        codeExchangePromise,
+        new Promise<null>((_, reject) => setTimeout(() => reject('Cancelled'), 60000))
+      ]);
+      this._tokenInformation = resp as TokenInformation;
+      return resp?.access_token;
+    } finally {
+      loopbackClient.closeServer();
+      this._pendingStates = this._pendingStates.filter(n => n !== stateId);
+      this._codeVerfifiers.delete(stateId);
+      this._scopes.delete(stateId);
+    }
+  }
+
+  private async getAccessTokenByRefreshToken(refreshToken: string, clientId: string): Promise<TokenInformation> {
+    const postData = new URLSearchParams({
+      grant_type: 'refresh_token',
+      client_id: clientId,
+      refresh_token: refreshToken
+    }).toString();
+
+    const response = await fetch(this.tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Length': postData.length.toString()
+      },
+      body: postData
+    });
+
+    if (response.status !== 200) {
+      const error = await response.json();
+      throw new Error(`Failed to retrieve access token: ${response.status} ${error}`);
+    }
+
+    const { access_token, refresh_token } = await response.json();
+
+
+    return { access_token, refresh_token };
+  }
+
+
+  private async _handleCallback(uri: Uri): Promise<TokenInformation> {
+    const query = new URLSearchParams(uri.query);
+    const code = query.get('code');
+    const stateId = query.get('state');
+
+    if (!code) {
+      throw new Error('No code');
+
+    }
+    if (!stateId) {
+      throw new Error('No state');
+
+    }
+
+    const codeVerifier = this._codeVerfifiers.get(stateId);
+    if (!codeVerifier) {
+      throw new Error('No code verifier');
+    }
+
+    // Check if it is a valid auth request started by the extension
+    if (!this._pendingStates.some(n => n === stateId)) {
+      throw new Error('State not found');
+    }
+
+    const postData = new URLSearchParams({
+      grant_type: 'authorization_code',
+      client_id: this.clientId,
+      code,
+      code_verifier: codeVerifier,
+      redirect_uri: this.redirectUri,
+    }).toString();
+
+    const response = await fetch(`${this.tokenEndpoint}`, {
+      method: 'POST',
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        'Content-Length': postData.length.toString()
+      },
+      body: postData
+    });
+
+    const { access_token, refresh_token } = await response.json();
+    return { access_token, refresh_token };
+  }
+
+  /**
+   * Get all required scopes
+   * @param scopes
+   */
+  private getScopes(scopes: string[] = []): string[] {
+    const modifiedScopes = [...scopes];
+
+    if (!modifiedScopes.includes('offline_access')) {
+      modifiedScopes.push('offline_access');
+    }
+    if (!modifiedScopes.includes('openid')) {
+      modifiedScopes.push('openid');
+    }
+    if (!modifiedScopes.includes('profile')) {
+      modifiedScopes.push('profile');
+    }
+    if (!modifiedScopes.includes('email')) {
+      modifiedScopes.push('email');
+    }
+
+    return modifiedScopes.sort();
+  }
+}
+
+export function toBase64UrlEncoding(buffer: Buffer) {
+  return buffer.toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+}
+
+export function sha256(buffer: string | Uint8Array): Buffer {
+  return crypto.createHash('sha256').update(buffer).digest();
+}

--- a/src/utils/auth/oidcClient.ts
+++ b/src/utils/auth/oidcClient.ts
@@ -11,6 +11,7 @@ import { env, Uri, window } from "vscode";
 import { IRestClientSettings, SystemSettings } from '../../models/configurationSettings';
 import { MemoryCache } from '../memoryCache';
 import { getCurrentHttpFileName, getWorkspaceRootPath } from '../workspaceUtility';
+import sanitizeHtml from 'sanitize-html';
 
 type ServerAuthorizationCodeResponse = {
   // Success case
@@ -92,7 +93,7 @@ export class CodeLoopbackClient {
           res.writeHead(302, { location: redirectUri }); // Prevent auth code from being saved in the browser history
           res.end();
         } else {
-          res.end(`Authorization Server Error:${JSON.stringify(authCodeResponse)}`);
+          res.end(`Authorization Server Error:${sanitizeHtml(JSON.stringify(authCodeResponse))}`);
           reject(new Error(`Authorization Server Error:${JSON.stringify(authCodeResponse)}`));
         }
         resolve({ url, ...authCodeResponse });
@@ -467,7 +468,7 @@ export class OidcClient {
 
     if (response.status !== 200) {
       const error = await response.json();
-      throw new Error(`Failed to retrieve access token: ${response.status} ${error}`);
+      throw new Error(`Failed to retrieve access token: ${response.status} ${JSON.stringify(error)}`);
     }
 
     const { access_token, refresh_token } = await response.json();

--- a/src/utils/auth/oidcClient.ts
+++ b/src/utils/auth/oidcClient.ts
@@ -535,8 +535,8 @@ export class OidcClient {
    */
   private getScopes(scopes: string[] = []): string[] {
     const settings = SystemSettings.Instance as IRestClientSettings;
-    
-    let modifiedScopes = [...(settings.oidcScopes ?? []), ...scopes];
+
+    const modifiedScopes = [...(settings.oidcScopes ?? []), ...scopes];
     return Array.from(new Set(modifiedScopes.sort()));
   }
 }

--- a/src/utils/httpElementFactory.ts
+++ b/src/utils/httpElementFactory.ts
@@ -139,6 +139,12 @@ export class HttpElementFactory {
             Constants.AzureActiveDirectoryDescription,
             new SnippetString(`{{$\${name:${Constants.AzureActiveDirectoryVariableName.slice(1)}}}}`)));
         originalElements.push(new HttpElement(
+                Constants.OidcVariableName,
+                ElementType.SystemVariable,
+                null,
+                Constants.OidcDescription,
+                new SnippetString(`{{$\${name:${Constants.OidcVariableName.slice(1)}}}}`)));
+        originalElements.push(new HttpElement(
             Constants.AzureActiveDirectoryV2TokenVariableName,
             ElementType.SystemVariable,
             null,

--- a/src/utils/httpVariableProviders/systemVariableProvider.ts
+++ b/src/utils/httpVariableProviders/systemVariableProvider.ts
@@ -38,7 +38,7 @@ export class SystemVariableProvider implements HttpVariableProvider {
     private readonly requestUrlRegex: RegExp = /^(?:[^\s]+\s+)([^:]*:\/\/\/?[^/\s]*\/?)/;
 
     private readonly aadRegex: RegExp = new RegExp(`\\s*\\${Constants.AzureActiveDirectoryVariableName}(\\s+(${Constants.AzureActiveDirectoryForceNewOption}))?(\\s+(ppe|public|cn|de|us))?(\\s+([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))?(\\s+aud:([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))?\\s*`);
-    private readonly oidcRegex: RegExp = new RegExp(`\\s*(\\${Constants.OidcVariableName})(?:\\s+(${Constants.OIdcForceNewOption}))?(?:\\s*clientId:([\\w|\.|:|/|_|-]+))?(?:\\s*issuer:([\\w|\.|:|/]+))?(?:\\s*callbackPort:([\\w|_]+))?(?:\\s*authorizeEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*tokenEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*scopes:([\\w|\.|:|/|_|-]+))?(?:\\s*audience:([\\w|\.|:|/|_|-]+))?`);
+    private readonly oidcRegex: RegExp = new RegExp(`\\s*(\\${Constants.OidcVariableName})(?:\\s+(${Constants.OIdcForceNewOption}))?(?:\\s*clientId:([\\w|\.|:|/|_|-]+))?(?:\\s*issuer:([\\w|\.|:|/]+))?(?:\\s*callbackDomain:([\\w|\.|:|/|_|-]+))?(?:\\s*callbackPort:([\\w|_]+))?(?:\\s*authorizeEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*tokenEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*scopes:([\\w|\.|:|/|_|-]+))?(?:\\s*audience:([\\w|\.|:|/|_|-]+))?`);
 
     private readonly innerSettingsEnvironmentVariableProvider: EnvironmentVariableProvider =  EnvironmentVariableProvider.Instance;
     private static _instance: SystemVariableProvider;
@@ -290,9 +290,9 @@ export class SystemVariableProvider implements HttpVariableProvider {
     private registerOidcTokenVariable() {
         this.resolveFuncs.set(Constants.OidcVariableName, async (name, document, context) => {
             const matchVar = this.oidcRegex.exec(name) ?? [];
-            const [_, _1, forceNew, clientId, _3, callbackPort, authorizeEndpoint, tokenEndpoint,  scopes, audience] = matchVar;
+            const [_, _1, forceNew, clientId, _3, callbackDomain, callbackPort, authorizeEndpoint, tokenEndpoint,  scopes, audience] = matchVar;
 
-            const access_token = await OidcClient.getAccessToken(forceNew ? true : false, clientId, parseInt(callbackPort ?? CALLBACK_PORT), authorizeEndpoint, tokenEndpoint, scopes, audience);
+            const access_token = await OidcClient.getAccessToken(forceNew ? true : false, clientId, callbackDomain, parseInt(callbackPort ?? CALLBACK_PORT), authorizeEndpoint, tokenEndpoint, scopes, audience);
             await this.clipboard.writeText(access_token ?? "");
             return { value: access_token ?? "" };
         });

--- a/src/utils/httpVariableProviders/systemVariableProvider.ts
+++ b/src/utils/httpVariableProviders/systemVariableProvider.ts
@@ -38,7 +38,7 @@ export class SystemVariableProvider implements HttpVariableProvider {
     private readonly requestUrlRegex: RegExp = /^(?:[^\s]+\s+)([^:]*:\/\/\/?[^/\s]*\/?)/;
 
     private readonly aadRegex: RegExp = new RegExp(`\\s*\\${Constants.AzureActiveDirectoryVariableName}(\\s+(${Constants.AzureActiveDirectoryForceNewOption}))?(\\s+(ppe|public|cn|de|us))?(\\s+([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))?(\\s+aud:([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))?\\s*`);
-    private readonly oidcRegex: RegExp = new RegExp(`\\s*(\\${Constants.OidcVariableName})(?:\\s+(${Constants.OIdcForceNewOption}))?(?:\\s*clientId:([\\w|-]+))?(?:\\s*issuer:([\\w|\.|:|/]+))?(?:\\s*callbackPort:([\\w|_]+))?(?:\\s*authorizeEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*tokenEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*scopes:([\\w|,]+))?(?:\\s*audience:(\\w+))?`);
+    private readonly oidcRegex: RegExp = new RegExp(`\\s*(\\${Constants.OidcVariableName})(?:\\s+(${Constants.OIdcForceNewOption}))?(?:\\s*clientId:([\\w|\.|:|/|_|-]+))?(?:\\s*issuer:([\\w|\.|:|/]+))?(?:\\s*callbackPort:([\\w|_]+))?(?:\\s*authorizeEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*tokenEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*scopes:([\\w|\.|:|/|_|-]+))?(?:\\s*audience:([\\w|\.|:|/|_|-]+))?`);
 
     private readonly innerSettingsEnvironmentVariableProvider: EnvironmentVariableProvider =  EnvironmentVariableProvider.Instance;
     private static _instance: SystemVariableProvider;

--- a/src/utils/httpVariableProviders/systemVariableProvider.ts
+++ b/src/utils/httpVariableProviders/systemVariableProvider.ts
@@ -38,7 +38,7 @@ export class SystemVariableProvider implements HttpVariableProvider {
     private readonly requestUrlRegex: RegExp = /^(?:[^\s]+\s+)([^:]*:\/\/\/?[^/\s]*\/?)/;
 
     private readonly aadRegex: RegExp = new RegExp(`\\s*\\${Constants.AzureActiveDirectoryVariableName}(\\s+(${Constants.AzureActiveDirectoryForceNewOption}))?(\\s+(ppe|public|cn|de|us))?(\\s+([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))?(\\s+aud:([^\\.]+\\.[^\\}\\s]+|[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}))?\\s*`);
-    private readonly oidcRegex: RegExp = new RegExp(`\\s*(\\${Constants.OidcVariableName})(?:\\s+(${Constants.OIdcForceNewOption}))?(?:\\s*clientId:([\\w|\.|:|/|_|-]+))?(?:\\s*issuer:([\\w|\.|:|/]+))?(?:\\s*callbackDomain:([\\w|\.|:|/|_|-]+))?(?:\\s*callbackPort:([\\w|_]+))?(?:\\s*authorizeEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*tokenEndpoint:([\\w|\.|:|/|_|-]+))?(?:\\s*scopes:([\\w|\.|:|/|_|-]+))?(?:\\s*audience:([\\w|\.|:|/|_|-]+))?`);
+    private readonly oidcRegex: RegExp = new RegExp(`\\s*(\\${Constants.OidcVariableName})(?:\\s+(${Constants.OIdcForceNewOption}))?(?:\\s*clientId:([\\w|.|:|/|_|-]+))?(?:\\s*issuer:([\\w|.|:|/]+))?(?:\\s*callbackDomain:([\\w|.|:|/|_|-]+))?(?:\\s*callbackPort:([\\w|_]+))?(?:\\s*authorizeEndpoint:([\\w|.|:|/|_|-]+))?(?:\\s*tokenEndpoint:([\\w|.|:|/|_|-]+))?(?:\\s*scopes:([\\w|.|:|/|_|-]+))?(?:\\s*audience:([\\w|.|:|/|_|-]+))?`);
 
     private readonly innerSettingsEnvironmentVariableProvider: EnvironmentVariableProvider =  EnvironmentVariableProvider.Instance;
     private static _instance: SystemVariableProvider;

--- a/src/utils/memoryCache.ts
+++ b/src/utils/memoryCache.ts
@@ -16,15 +16,15 @@ export class MemoryCache<T> {
         return this.caches.get(name) as MemoryCache<T>;
     }
 
-    public  get(key: string): T | undefined {
+    public get(key: string): T | undefined {
         return this.cache.get(key);
     }
 
-    public  set(key: string, value: T) {
+    public set(key: string, value: T) {
         this.cache.set(key, value);
     }
 
-    public  clear(): void {
+    public clear(): void {
         this.cache.clear();
     }
 }

--- a/src/utils/memoryCache.ts
+++ b/src/utils/memoryCache.ts
@@ -1,0 +1,30 @@
+export class OidcPayload {
+    public access_token: string;
+    public refresh_token: string;
+}
+
+export class MemoryCache<T> {
+    private cache = new Map<string, T>();
+    private static caches = new Map<string, MemoryCache<any>>();
+
+    public static createOrGet<T>(name: string): MemoryCache<T> {
+        if (!this.caches.has(name)) {
+            const cache = new MemoryCache<T>();
+            this.caches.set(name, cache);
+            return cache;
+        }
+        return this.caches.get(name) as MemoryCache<T>;
+    }
+
+    public  get(key: string): T | undefined {
+        return this.cache.get(key);
+    }
+
+    public  set(key: string, value: T) {
+        this.cache.set(key, value);
+    }
+
+    public  clear(): void {
+        this.cache.clear();
+    }
+}


### PR DESCRIPTION
The pull request adds support for OIDC access tokens. It uses PKCE flow to acquire tokens - no stored secrets required. The tokens are cached, and refresh token is used when the access token is expired. It can be used with any identity provider which supports PKCE OpenID Connect flow.

Example for Google:
```
GET https://openidconnect.googleapis.com/v1/userinfo
Authorization: Bearer {{$oidcAccessToken clientId:786371393912-ahu1p5p81n2pj4fa90bo33pirr1mroeu.apps.googleusercontent.com callbackPort:7777 authorizeEndpoint:https://accounts.google.com/o/oauth2/v2/auth tokenEndpoint:https://oauth2.googleapis.com/token}}
Accept: application/json
```
Example for Microsoft:
```
GET https://graph.microsoft.com/oidc/userinfo
Authorization: Bearer {{$oidcAccessToken clientId:336c0138-03e7-4183-a398-3e63445dd5f5 callbackPort:7777 authorizeEndpoint:https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize tokenEndpoint:https://login.microsoftonline.com/consumers/oauth2/v2.0/token}}
Accept: application/json
```

The example will call an API with google access token. For google the app should be registered as UWP to use PKCE without the client secret.
