### PR TITLE
Remove incorrect question mark from requestline regex

### DIFF
--- a/syntaxes/http.tmLanguage.json
+++ b/syntaxes/http.tmLanguage.json
@@ -258,7 +258,7 @@
           ]
         }
       },
-      "match": "(?i)^(?:(get|post|put|delete|patch|head|options|connect|trace|lock|unlock|propfind|proppatch|copy|move|mkcol|mkcalendar|acl|search)\\s+)?\\s*(.+?)(?:\\s+(HTTP\\/\\S+))?$",
+      "match": "(?i)^(?:(get|post|put|delete|patch|head|options|connect|trace|lock|unlock|propfind|proppatch|copy|move|mkcol|mkcalendar|acl|search)\\s+)\\s*(.+?)(?:\\s+(HTTP\\/\\S+))?$",
       "name": "http.requestline"
     },
     "response-line": {


### PR DESCRIPTION
Fixes #955

The current regex matches 
`HTTP/1.1 200 OK` as `requestline` instead of`responseline` this is because the regex is too lenient allowing no METHOD field.
According to the RFC (https://datatracker.ietf.org/doc/html/rfc2616#section-5.1) METHOD has to exist and be not empty for the request line.
You can test the regex at https://regex101.com/
