### PR TITLE
Increase XDG directory specification adherence

### DIFF
--- a/src/utils/userDataManager.ts
+++ b/src/utils/userDataManager.ts
@@ -18,6 +18,10 @@ function getCachePath(): string {
         return path.join(process.env.XDG_CACHE_HOME, restClientDir);
     }
 
+    if (os.platform() === 'linux') {
+        return path.join(os.homedir(), '.cache', restClientDir);
+    }
+
     return rootPath;
 }
 
@@ -28,6 +32,10 @@ function getStatePath(): string {
 
     if (process.env.XDG_STATE_HOME !== undefined) {
         return path.join(process.env.XDG_STATE_HOME, restClientDir);
+    }
+
+    if (os.platform() === 'linux') {
+        return path.join(os.homedir(), '.local', 'state', restClientDir);
     }
 
     return rootPath;


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/latest/) has pre-defined defaults for when the respective environment variables are not set. Many Linux distros explicitly set them to be equivalent to the default, but not all do.

This PR makes it so that when those variables are not set on a Linux system, the user directories will be created on the respective defaults. Setting the variables to a different value will still have precedence, as will a pre-existing user directory in the home folder.