### PR TITLE
chore: update uuid from v3 to v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "sanitize-html": "^2.13.0",
         "tough-cookie": "^4.1.3",
         "tough-cookie-file-store": "^2.0.3",
-        "uuid": "^3.3.2",
+        "uuid": "^11.1.0",
         "xmldom": "^0.5.0",
         "xpath": "^0.0.27",
         "yargs-parser": "^21.1.1"
@@ -90,6 +90,16 @@
         "uuid": "^3.2.1"
       }
     },
+    "node_modules/@aws-amplify/analytics/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/@aws-amplify/api": {
       "version": "5.4.13",
       "resolved": "https://registry.npmjs.org/@aws-amplify/api/-/api-5.4.13.tgz",
@@ -114,6 +124,16 @@
         "tslib": "^1.8.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/@aws-amplify/api-graphql/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/@aws-amplify/api-rest": {
@@ -216,6 +236,16 @@
         "zen-push": "0.2.1"
       }
     },
+    "node_modules/@aws-amplify/datastore/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/@aws-amplify/geo": {
       "version": "2.3.13",
       "resolved": "https://registry.npmjs.org/@aws-amplify/geo/-/geo-2.3.13.tgz",
@@ -254,6 +284,16 @@
         "uuid": "^3.2.1"
       }
     },
+    "node_modules/@aws-amplify/notifications/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/@aws-amplify/predictions": {
       "version": "5.5.14",
       "resolved": "https://registry.npmjs.org/@aws-amplify/predictions/-/predictions-5.5.14.tgz",
@@ -273,6 +313,16 @@
         "uuid": "^3.2.1"
       }
     },
+    "node_modules/@aws-amplify/predictions/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/@aws-amplify/pubsub": {
       "version": "5.5.13",
       "resolved": "https://registry.npmjs.org/@aws-amplify/pubsub/-/pubsub-5.5.13.tgz",
@@ -287,6 +337,16 @@
         "url": "0.11.0",
         "uuid": "^3.2.1",
         "zen-observable-ts": "0.8.19"
+      }
+    },
+    "node_modules/@aws-amplify/pubsub/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/@aws-amplify/rtn-push-notification": {
@@ -499,6 +559,16 @@
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
+    },
+    "node_modules/@aws-sdk/client-comprehend/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
     },
     "node_modules/@aws-sdk/client-firehose": {
       "version": "3.6.1",
@@ -4095,6 +4165,16 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
       "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
+    "node_modules/@aws-sdk/client-translate/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/@aws-sdk/config-resolver": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.6.1.tgz",
@@ -4589,6 +4669,16 @@
       },
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-retry/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sts": {
@@ -9639,6 +9729,16 @@
       },
       "engines": {
         "node": ">= 0.6.15"
+      }
+    },
+    "node_modules/adal-node/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "license": "MIT",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/agent-base": {
@@ -17014,12 +17114,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package.json
+++ b/package.json
@@ -749,7 +749,7 @@
     "sanitize-html": "^2.13.0",
     "tough-cookie": "^4.1.3",
     "tough-cookie-file-store": "^2.0.3",
-    "uuid": "^3.3.2",
+    "uuid": "^11.1.0",
     "xmldom": "^0.5.0",
     "xpath": "^0.0.27",
     "yargs-parser": "^21.1.1"

--- a/src/controllers/historyController.ts
+++ b/src/controllers/historyController.ts
@@ -3,6 +3,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import * as fs from 'fs-extra';
 import { EOL, tmpdir } from 'os';
 import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 import { QuickPickItem, window, workspace } from 'vscode';
 import { HistoricalHttpRequest } from '../models/httpRequest';
 import { trace } from "../utils/decorator";
@@ -10,8 +11,6 @@ import { formatHeaders } from '../utils/misc';
 import { UserDataManager } from '../utils/userDataManager';
 
 dayjs.extend(relativeTime);
-
-const uuidv4 = require('uuid/v4');
 
 export class HistoryController {
     public constructor() {

--- a/src/utils/auth/digest.ts
+++ b/src/utils/auth/digest.ts
@@ -1,10 +1,8 @@
 import * as url from 'url';
+import { v4 as uuidv4 } from 'uuid';
 import { md5 } from '../misc';
 
 import got = require('got');
-
-const uuidv4 = require('uuid/v4');
-
 export function digest(user: string, pass: string): got.AfterResponseHook {
     return (response, retryWithMergedOptions) => {
         if (response.statusCode === 401

--- a/src/utils/httpVariableProviders/systemVariableProvider.ts
+++ b/src/utils/httpVariableProviders/systemVariableProvider.ts
@@ -4,6 +4,7 @@ import utc from 'dayjs/plugin/utc';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs-extra';
 import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
 import { Clipboard, commands, env, QuickPickItem, QuickPickOptions, TextDocument, Uri, window } from 'vscode';
 import * as Constants from '../../common/constants';
 import { EnvironmentController } from '../../controllers/environmentController';
@@ -16,8 +17,6 @@ import { CALLBACK_PORT, OidcClient } from '../auth/oidcClient';
 import { HttpClient } from '../httpClient';
 import { EnvironmentVariableProvider } from './environmentVariableProvider';
 import { HttpVariable, HttpVariableContext, HttpVariableProvider } from './httpVariableProvider';
-
-const uuidv4 = require('uuid/v4');
 
 dayjs.extend(utc);
 


### PR DESCRIPTION
update uuid from v3 to v11
- uuid v3 is deprecated
  - <https://www.npmjs.com/package/uuid/v/3.3.2> 
- <https://github.com/uuidjs/uuid/blob/main/CHANGELOG.md>