### PR TITLE
feat: Support converting json data into form for submission

### DIFF
--- a/src/models/configurationSettings.ts
+++ b/src/models/configurationSettings.ts
@@ -50,6 +50,7 @@ export interface IRestClientSettings {
     readonly enableSendRequestCodeLens: boolean;
     readonly enableCustomVariableReferencesCodeLens: boolean;
     readonly useContentDispositionFilename: boolean;
+    readonly jsonToForm?: boolean;
 }
 
 export class SystemSettings implements IRestClientSettings {
@@ -319,6 +320,8 @@ export class RequestSettings implements Partial<IRestClientSettings> {
     private _followRedirect?: boolean = undefined;
 
     private _rememberCookiesForSubsequentRequests?: boolean = undefined;
+    
+    private _jsonToForm?: boolean = undefined;
 
     public get followRedirect() {
         return this._followRedirect;
@@ -328,11 +331,19 @@ export class RequestSettings implements Partial<IRestClientSettings> {
         return this._rememberCookiesForSubsequentRequests;
     }
 
+    public get jsonToForm() {
+        return this._jsonToForm;
+    }
+
     public constructor(metadatas: Map<RequestMetadata, string | undefined>) {
         if (metadatas.has(RequestMetadata.NoRedirect)) {
             this._followRedirect = false;
         } else if (metadatas.has(RequestMetadata.NoCookieJar)) {
             this._rememberCookiesForSubsequentRequests = false;
+        }
+
+        if (metadatas.has(RequestMetadata.JsonToForm)) {
+            this._jsonToForm = true;
         }
     }
 }
@@ -469,6 +480,10 @@ export class RestClientSettings implements IRestClientSettings {
 
     public get useContentDispositionFilename() {
         return this.systemSettings.useContentDispositionFilename;
+    }
+
+    public get jsonToForm() {
+        return this.requestSettings.jsonToForm;
     }
 
     private readonly systemSettings = SystemSettings.Instance;

--- a/src/models/requestMetadata.ts
+++ b/src/models/requestMetadata.ts
@@ -21,6 +21,11 @@ export enum RequestMetadata {
      * Used to allow user to interactively input variables for this request
      */
     Prompt = 'prompt',
+
+    /**
+     * Represents a directive to automatically URL encode a JSON request body
+     */
+    JsonToForm = 'jsontoform',
 }
 
 export function fromString(value: string): RequestMetadata | undefined {

--- a/src/utils/httpRequestParser.ts
+++ b/src/utils/httpRequestParser.ts
@@ -99,6 +99,38 @@ export class HttpRequestParser implements RequestParser {
         let body = await this.parseBody(bodyLines, contentTypeHeader);
         if (isGraphQlRequest) {
             body = await this.createGraphQlBody(variableLines, contentTypeHeader, body);
+        } else if (this.settings.jsonToForm && typeof body === 'string') {
+            try {
+                // Strip redundant quotes around JSON objects/arrays to fix unescaped quote errors
+                const fixedBody = body.replace(/"\s*(\{[\s\S]*?\})\s*"/g, "$1").replace(/"\s*(\[[\s\S]*?\])\s*"/g, "$1");
+                const { parse } = require('jsonc-parser');
+                const errors: any[] = [];
+                const parsedJson = parse(fixedBody, errors, { allowTrailingComma: true });
+                if (errors.length > 0) {
+                    throw new Error(`JSON parsing failed at offset ${errors[0].offset} with length ${errors[0].length}.`);
+                }
+                const encodedStringPairs: string[] = [];
+                for (const key in parsedJson) {
+                    if (parsedJson.hasOwnProperty(key)) {
+                        const value = parsedJson[key];
+                        // If value is object/array, stringify it first
+                        const stringValue = typeof value === 'object' ? JSON.stringify(value) : String(value);
+                        encodedStringPairs.push(`${encodeURIComponent(key)}=${encodeURIComponent(stringValue)}`);
+                    }
+                }
+                body = encodedStringPairs.join('&');
+                
+                // Force the content-type to be application/x-www-form-urlencoded if it was converted
+                const contentTypeKey = Object.keys(headers).find(k => k.toLowerCase() === 'content-type');
+                if (contentTypeKey) {
+                    headers[contentTypeKey] = 'application/x-www-form-urlencoded';
+                } else {
+                    headers['Content-Type'] = 'application/x-www-form-urlencoded';
+                }
+            } catch (err) {
+                // Return descriptive error from JSON parse failure so the request errors out usefully
+                throw new Error(`Invalid JSON format for @jsonToForm directive: ${err.message}`);
+            }
         } else if (this.settings.formParamEncodingStrategy !== FormParamEncodingStrategy.Never && typeof body === 'string' && MimeUtility.isFormUrlEncoded(contentTypeHeader)) {
             if (this.settings.formParamEncodingStrategy === FormParamEncodingStrategy.Always) {
                 const stringPairs = body.split('&');


### PR DESCRIPTION
Supports converting the following json data into application/x-www-form-urlencoded type before submitting it

```
###
# @jsonToForm
POST https://httpbin.org/post 

{
  "resp_desc" : "交易成功[000]",
  "resp_code" : "00000000",
  "sign" : "123+456",
  "resp_data" : "{"acct_date":"20260305"}",
}
```

can be converted to the following curl request

```
curl --request POST \
  --url https://httpbin.org/post  \
  --header 'Content-Type: application/x-www-form-urlencoded' \
  --header 'User-Agent: vscode-restclient' \
  --data 'resp_desc=交易成功[000]' \
  --data resp_code=00000000 \
  --data 'sign=123+456' \
  --data 'resp_data={"acct_date":"20260305"}'
```