### PR TITLE
fix: handle Readable stream body and avoid mutating original headers in AWS signing

### DIFF
--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -19,6 +19,7 @@ import { getCurrentHttpFileName, getWorkspaceRootPath } from './workspaceUtility
 
 import { CancelableRequest, Headers, Method, OptionsOfBufferResponseBody, Response } from 'got';
 import got = require('got');
+import crypto = require('crypto');
 
 const encodeUrl = require('encodeurl');
 const CookieFileStore = require('tough-cookie-file-store').FileCookieStore;
@@ -112,17 +113,28 @@ export class HttpClient {
     private async prepareOptions(httpRequest: HttpRequest, settings: IRestClientSettings): Promise<OptionsOfBufferResponseBody> {
         const originalRequestBody = httpRequest.body;
         let requestBody: string | Buffer | undefined;
-        if (originalRequestBody) {
-            if (typeof originalRequestBody !== 'string') {
-                requestBody = await convertStreamToBuffer(originalRequestBody);
-            } else {
-                requestBody = originalRequestBody;
-            }
-        }
 
         // Fix #682 Do not touch original headers in httpRequest, which may be used for retry later
         // Simply do a shadow copy here
         const clonedHeaders = Object.assign({}, httpRequest.headers);
+
+        const authorization = getHeader(clonedHeaders, 'Authorization') as string | undefined;
+        if (originalRequestBody) {
+            if (typeof originalRequestBody !== 'string') {
+                const buffer = await convertStreamToBuffer(originalRequestBody);
+                requestBody = buffer;
+                
+                if (authorization) {
+                    const [scheme] = authorization.split(/\s+/);
+                    const normalizedScheme = scheme.toLowerCase();
+                    if (normalizedScheme === 'aws' || normalizedScheme === 'cognito') {
+                        clonedHeaders['X-Amz-Content-Sha256'] = crypto.createHash('sha256').update(buffer).digest('hex');
+                    }
+                }
+            } else {
+                requestBody = originalRequestBody;
+            }
+        }
 
         const options: OptionsOfBufferResponseBody = {
             headers: clonedHeaders as any as Headers,
@@ -151,7 +163,6 @@ export class HttpClient {
         }
 
         // TODO: refactor auth
-        const authorization = getHeader(options.headers!, 'Authorization') as string | undefined;
         if (authorization) {
             const [scheme, user, ...args] = authorization.split(/\s+/);
             const normalizedScheme = scheme.toLowerCase();


### PR DESCRIPTION
When `options.body` is an instance of `Readable` stream, the AWS Signature Version 4 (aws4) signing process fails with a `TypeError`. This is because the underlying `crypto.hash.update` method does not support stream inputs.

**Reproduction Case**:

```http
POST https://httpbin.org/post
Authorization: AWS {{aws_key}}
Content-Type: application/json

< empty.json
```

**Log Output**:

```log
TypeError: The "data" argument must be of type string or an instance of Buffer, TypedArray, or DataView. Received an instance of Readable
    at Hash.update (node:internal/crypto/hash:140:11)
    at l (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:132:333)
    at d.canonicalString (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:132:4570)
    at d.stringToSign (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:132:4109)
    at d.signature (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:132:3974)
    at d.authHeader (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:132:3667)
    at d.sign (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:132:3086)
    at n.sign (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:132:6404)
    at /root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:558:2499
    at Immediate.<anonymous> (/root/.vscode-server/extensions/humao.rest-client-0.25.1/dist/extension.js:252:4462)
    at process.processImmediate (node:internal/timers:484:21)
    at process.callbackTrampoline (node:internal/async_hooks:130:17)
```