### PR TITLE
fix: response preview not shown when viewColumn is undefined (Cursor)

### DIFF
--- a/src/controllers/requestController.ts
+++ b/src/controllers/requestController.ts
@@ -113,14 +113,11 @@ export class RequestController {
             }
 
             try {
-                const activeColumn = window.activeTextEditor!.viewColumn;
-                const previewColumn = settings.previewColumn === ViewColumn.Active
-                    ? activeColumn
-                    : ((activeColumn as number) + 1) as ViewColumn;
+                const previewColumn = this.resolvePreviewColumn(settings, document);
                 if (settings.previewResponseInUntitledDocument) {
-                    this._textDocumentView.render(response, previewColumn);
-                } else if (previewColumn) {
-                    this._webview.render(response, previewColumn);
+                    await this._textDocumentView.render(response, previewColumn);
+                } else {
+                    await this._webview.render(response, previewColumn);
                 }
             } catch (reason) {
                 Logger.error('Unable to preview response:', reason);
@@ -150,6 +147,19 @@ export class RequestController {
                 this._lastPendingRequest = undefined;
             }
         }
+    }
+
+    private resolvePreviewColumn(settings: IRestClientSettings, document?: TextDocument): ViewColumn {
+        if (settings.previewColumn !== ViewColumn.Active) {
+            return settings.previewColumn;
+        }
+
+        const requestEditor = document
+            ? window.visibleTextEditors.find(editor => editor.document === document)
+            : undefined;
+        const editor = requestEditor ?? window.activeTextEditor;
+
+        return editor?.viewColumn ?? ViewColumn.One;
     }
 
     public dispose() {


### PR DESCRIPTION
## Summary

Fixes #1434

When `rest-client.previewColumn` is set to `beside` (the default), the extension computed the preview column as `activeTextEditor.viewColumn + 1` instead of using `ViewColumn.Beside`. On Cursor (and some VS Code layouts), `viewColumn` is often `undefined` when the Chat/Agent panel is open or focus is not on the `.http` editor. This produced `undefined` or `NaN` as the preview column, and the `else if (previewColumn)` guard silently skipped rendering — the request completed successfully but no response tab appeared.

This matches the workaround reported in #1434: splitting the editor (`Cmd+\`) before sending a request forces a second column to exist, which made preview work.

## Changes

- Add `resolvePreviewColumn()` that returns `settings.previewColumn` directly for `beside`
- For `current`, resolve the column from the request document's visible editor, with fallback to `ViewColumn.One`
- Remove the falsy `previewColumn` guard so preview always renders
- `await` the render calls

## Test plan

- [x] Send request in Cursor with only a single editor column (no split) — response tab opens beside the request
- [x] Send request with Cursor Chat panel open — response tab still opens
- [x] Send request with `rest-client.previewColumn` set to `current` — response opens in the request column
- [x] `npm run webpack` compiles successfully


Made with [Cursor](https://cursor.com)